### PR TITLE
Fix use of FindYAML.cmake and FindJSONCPP without pkg-config

### DIFF
--- a/cmake/FindJSONCPP.cmake
+++ b/cmake/FindJSONCPP.cmake
@@ -38,7 +38,7 @@ else()
   if(JSONCPP_FOUND)
     ign_pkg_config_entry(JSONCPP jsoncpp)
   else()
-    ign_pkg_check_modules(JSONCPP jsoncpp)
+    ign_pkg_check_modules_quiet(JSONCPP jsoncpp)
     set(JSONCPP_TARGET JSONCPP::JSONCPP)
 
     # If that failed, then fall back to manual detection.
@@ -70,11 +70,10 @@ else()
         include(IgnImportTarget)
         ign_import_target(JSONCPP)
       endif()
-
-      include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(
-        JSONCPP
-        REQUIRED_VARS JSONCPP_FOUND)
     endif()
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+      JSONCPP
+      REQUIRED_VARS JSONCPP_FOUND)
   endif()
 endif()

--- a/cmake/FindYAML.cmake
+++ b/cmake/FindYAML.cmake
@@ -52,7 +52,7 @@ if(YAML_FIND_VERSION AND NOT YAML_FIND_VERSION VERSION_EQUAL "0.1")
                   "but you requested version ${YAML_FIND_VERSION}.")
 else()
   include(IgnPkgConfig)
-  ign_pkg_check_modules(YAML yaml-0.1)
+  ign_pkg_check_modules_quiet(YAML yaml-0.1)
 
   # If that failed, then fall back to manual detection.
   if(NOT YAML_FOUND)
@@ -87,10 +87,10 @@ else()
         INTERFACE_COMPILE_DEFINITIONS "YAML_DECLARE_STATIC"
       )
     endif()
-
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(
-      YAML
-      REQUIRED_VARS YAML_FOUND)
   endif()
+  
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    YAML
+    REQUIRED_VARS YAML_FOUND)
 endif()


### PR DESCRIPTION
In particular, fix their use if the corresponding CMake config file is not found, and at the same time `pkg-config` is not found in the system.

Related fix: 
* https://github.com/ignitionrobotics/ign-cmake/commit/4ff79d0355fe2337e4588cf374cad63047752659
* https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-cmake/pull-requests/182/page/1#comment-141521720

@scpeters 