### PR TITLE
PR labeler 📜 🏰 🔮

### DIFF
--- a/.github/pr-branch-labeler.yml
+++ b/.github/pr-branch-labeler.yml
@@ -1,0 +1,7 @@
+📜 blueprint:
+  base: "ign-cmake2"
+🏰 citadel:
+  base: "ign-cmake2"
+🔮 dome:
+  base: "ign-cmake2"
+

--- a/.github/workflows/pr-branch-labeler.yml
+++ b/.github/workflows/pr-branch-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Branch Labeler
+
+on: pull_request
+
+jobs:
+  label_prs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label PRs
+      if: github.event.action == 'opened'
+      uses: chapulina/pr-branch-labeler@deb_v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses [this](https://github.com/ffittschen/pr-branch-labeler/tree/v1) GitHub action to automatically label pull requests targeting branches associated to a collection.

One drawback is that actions like these don't work for forks (yet?), so we'll still need to manually label PRs from forks.

Finally, it's cumbersome to have the collection-branch mapping on an extra file. A few ideas:
* Open a PR upstream making [CONFIG_FILENAME](https://github.com/ffittschen/pr-branch-labeler/blob/v1/src/main.ts#L7) configurable, so we can put the mapping on a more generic file that could be reused for other purposes.
* Creating our own action which pulls the mapping from some other central place.