### PR TITLE
PR collection labeler

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Collection Labeler
+
+on: pull_request
+
+jobs:
+  pr_collection_labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add collection labels
+      if: github.event.action == 'opened'
+      uses: ignition-tooling/pr-collection-labeler@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The same idea as #81, but it uses a custom action that pulls the branch mapping from `gazebodistro`:

https://github.com/ignition-tooling/pr-collection-labeler