### PR TITLE
Auto-triage tickets to core board

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,19 @@
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+name: Ticket opened
+jobs:
+  assign:
+    name: Add ticket to inbox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ticket to inbox
+        uses: technote-space/create-project-card-action@v1
+        with:
+          PROJECT: Core development
+          COLUMN: Inbox
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          CHECK_ORG_PROJECT: true
+


### PR DESCRIPTION
Uses this action: https://github.com/technote-space/create-project-card-action/tree/v1

Tickets are triaged by the @osrf-triage account, see the examples:

* Issue: https://github.com/ignitionrobotics/testing/issues/2
* PR: https://github.com/ignitionrobotics/testing/pull/3

It looks like the action is triggered for all issues as long as it's in the `master` branch.

But for PRs, it needs to be in the PR branch. See how the action didn't run for this PR: https://github.com/ignitionrobotics/testing/pull/4