### PR TITLE
Add support for finding several  dependencies without pkg-config

### DIFF
--- a/cmake/FindAVCODEC.cmake
+++ b/cmake/FindAVCODEC.cmake
@@ -16,4 +16,16 @@
 ########################################
 # Find avcodec
 include(IgnPkgConfig)
-ign_pkg_check_modules(AVCODEC libavcodec)
+ign_pkg_check_modules_quiet(AVCODEC libavcodec)
+
+if(NOT AVCODEC_FOUND)
+  include(IgnManualSearch)
+  ign_manual_search(AVCODEC
+                    HEADER_NAMES "libavcodec/avcodec.h"
+                    LIBRARY_NAMES "avcodec")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  AVCODEC
+  REQUIRED_VARS AVCODEC_FOUND)

--- a/cmake/FindAVDEVICE.cmake
+++ b/cmake/FindAVDEVICE.cmake
@@ -20,4 +20,36 @@ set(av_minor ${AVDEVICE_FIND_VERSION_MINOR})
 set(av_patch ${AVDEVICE_FIND_VERSION_PATCH})
 
 include(IgnPkgConfig)
-ign_pkg_check_modules(AVDEVICE "libavdevice >= ${av_major}.${av_minor}.${av_patch}")
+ign_pkg_check_modules_quiet(AVDEVICE "libavdevice >= ${av_major}.${av_minor}.${av_patch}")
+
+if(NOT AVDEVICE_FOUND)
+  include(IgnManualSearch)
+  ign_manual_search(AVDEVICE
+                    HEADER_NAMES "libavdevice/avdevice.h"
+                    LIBRARY_NAMES "avdevice")
+
+  # Version check
+  if(AVDEVICE_FOUND)
+    file(READ "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version.h" ver_file)
+
+    string(REGEX MATCH "LIBAVDEVICE_VERSION_MAJOR[ \t\r\n]+([0-9]*)" _ ${ver_file})
+    set(ver_major ${CMAKE_MATCH_1})
+
+    string(REGEX MATCH "LIBAVDEVICE_VERSION_MINOR[ \t\r\n]+([0-9]*)" _ ${ver_file})
+    set(ver_minor ${CMAKE_MATCH_1})
+
+    string(REGEX MATCH "LIBAVDEVICE_VERSION_MICRO[ \t\r\n]+([0-9]*)" _ ${ver_file})
+    set(ver_patch ${CMAKE_MATCH_1})
+
+    set(AVDEVICE_VERSION "${ver_major}.${ver_minor}.${ver_patch}")
+
+    if(AVDEVICE_VERSION VERSION_LESS AVDEVICE_FIND_VERSION)
+      set(AVDEVICE_FOUND FALSE)
+    endif()
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  AVDEVICE
+  REQUIRED_VARS AVDEVICE_FOUND)

--- a/cmake/FindAVFORMAT.cmake
+++ b/cmake/FindAVFORMAT.cmake
@@ -16,4 +16,16 @@
 ########################################
 # Find AV format
 include(IgnPkgConfig)
-ign_pkg_check_modules(AVFORMAT libavformat)
+ign_pkg_check_modules_quiet(AVFORMAT libavformat)
+
+if(NOT AVFORMAT_FOUND)
+  include(IgnManualSearch)
+  ign_manual_search(AVFORMAT
+                    HEADER_NAMES "libavformat/avformat.h"
+                    LIBRARY_NAMES "avformat")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  AVFORMAT
+  REQUIRED_VARS AVFORMAT_FOUND)

--- a/cmake/FindAVUTIL.cmake
+++ b/cmake/FindAVUTIL.cmake
@@ -16,4 +16,16 @@
 ########################################
 # Find avutil
 include(IgnPkgConfig)
-ign_pkg_check_modules(AVUTIL libavutil)
+ign_pkg_check_modules_quiet(AVUTIL libavutil)
+
+if(NOT AVUTIL_FOUND)
+  include(IgnManualSearch)
+  ign_manual_search(AVUTIL
+                    HEADER_NAMES "libavutil/avutil.h"
+                    LIBRARY_NAMES "avutil")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  AVUTIL
+  REQUIRED_VARS AVUTIL_FOUND)

--- a/cmake/FindSWSCALE.cmake
+++ b/cmake/FindSWSCALE.cmake
@@ -16,4 +16,16 @@
 ########################################
 # Find libswscale format
 include(IgnPkgConfig)
-ign_pkg_check_modules(SWSCALE libswscale)
+ign_pkg_check_modules_quiet(SWSCALE libswscale)
+
+if(NOT SWSCALE_FOUND)
+  include(IgnManualSearch)
+  ign_manual_search(SWSCALE
+                    HEADER_NAMES "libswscale/swscale.h"
+                    LIBRARY_NAMES "swscale")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  SWSCALE
+  REQUIRED_VARS SWSCALE_FOUND)

--- a/cmake/FindUUID.cmake
+++ b/cmake/FindUUID.cmake
@@ -17,5 +17,17 @@
 # Find uuid
 if (UNIX)
   include(IgnPkgConfig)
-  ign_pkg_check_modules(UUID uuid)
+  ign_pkg_check_modules_quiet(UUID uuid)
+
+  if(NOT UUID_FOUND)
+    include(IgnManualSearch)
+    ign_manual_search(UUID
+                      HEADER_NAMES "uuid/uuid.h"
+                      LIBRARY_NAMES "uuid libuuid")
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    UUID
+    REQUIRED_VARS UUID_FOUND)
 endif()

--- a/cmake/IgnManualSearch.cmake
+++ b/cmake/IgnManualSearch.cmake
@@ -1,0 +1,94 @@
+#===============================================================================
+# Copyright (C) 2020 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################
+# ign_manual_search(<package> [INTERFACE]
+#     [HEADER_NAMES <header_names>]
+#     [LIBRARY_NAMES <library_names>]
+#     [TARGET_NAME <target_name>])
+#
+# This macro will find a library based on the name of one of its headers,
+# and the library name.
+# It is used inside Find***.cmake scripts, typicall as fallback for a 
+# ign_pkg_check_modules_quiet call. 
+# It will create an imported target for the  library
+#
+# INTERFACE: Optional. Use INTERFACE when the target does not actually provide
+#            a library that needs to be linked against (e.g. it is a header-only
+#            library, or the target is just used to specify compiler flags).
+#
+# HEADER_NAMES: Optional. Explicitly specify the header names to search with find_path.
+#              Default is <package>.h.
+#
+# LIBRARY_NAMES: Optional. Explicitly specify the names of the library to search with find_library.
+#              Default is <package>.
+#
+# TARGET_NAME: Optional. Explicitly specify the desired imported target name.
+#              Default is <package>::<package>.
+#
+macro(ign_manual_search package)
+
+  #------------------------------------
+  # Define the expected arguments
+  set(options INTERFACE)
+  set(oneValueArgs "TARGET_NAME")
+  set(multiValueArgs "HEADER_NAMES" "LIBRARY_NAMES")
+
+  #------------------------------------
+  # Parse the arguments
+  _ign_cmake_parse_arguments(ign_manual_search "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(ign_manual_search_INTERFACE)
+    set(_ign_manual_search_interface_option INTERFACE)
+  else()
+    set(_ign_manual_search_interface_option) # Intentionally blank
+  endif()
+
+  if(NOT ign_manual_search_HEADER_NAMES)
+    set(ign_manual_search_HEADER_NAMES "${package}.h")
+  endif()
+  
+  if(NOT ign_manual_search_LIBRARY_NAMES)
+    set(ign_manual_search_LIBRARY_NAMES "${package}")
+  endif()
+
+  if(NOT ign_manual_search_TARGET_NAME)
+    set(ign_manual_search_TARGET_NAME "${package}::${package}")
+  endif()
+  
+  find_path(${package}_INCLUDE_DIRS
+            NAMES ${ign_manual_search_HEADER_NAMES})
+  find_library(${package}_LIBRARIES
+               NAMES ${ign_manual_search_LIBRARY_NAMES})
+  mark_as_advanced(${package}_INCLUDE_DIRS)
+  mark_as_advanced(${package}_LIBRARIES)
+  
+  set(${package}_FOUND true)
+
+  if(NOT ${package}_INCLUDE_DIRS)
+    set(${package}_FOUND false)
+  endif()
+
+  if(NOT ${package}_LIBRARIES)
+    set(${package}_FOUND false)
+  endif()
+
+  if(${package}_FOUND)
+    include(IgnImportTarget)
+    ign_import_target(${package} ${_ign_pkg_check_modules_interface_option}
+      TARGET_NAME ${ign_pkg_check_modules_TARGET_NAME})
+  endif()
+
+endmacro()


### PR DESCRIPTION
In particular, add a dedicated `ign_manual_search` CMake macro, and then use it in `FindUUID` (fix https://github.com/ignitionrobotics/ign-cmake/issues/64) and in the find scripts for FFMPEG libraries. 