### PR TITLE
Disable long-running buildsystem tests by default

### DIFF
--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -11,6 +11,20 @@ jobs:
         uses: actions/checkout@v2
       - name: Bionic CI
         id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@master
+        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
         with:
           apt-dependencies: 'pkg-config'
+  bionic-ci-plus:
+    runs-on: ubuntu-latest
+    name: Ubuntu Bionic CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bionic CI
+        id: ci
+        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
+        with:
+          apt-dependencies: 'pkg-config'
+          cmake-args: '-DBUILDSYSTEM_TESTING=True'
+
+

--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -11,20 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Bionic CI
         id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
-        with:
-          apt-dependencies: 'pkg-config'
-  bionic-ci-plus:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Bionic CI
-        id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
+        uses: ignition-tooling/ubuntu-bionic-ci-action@master
         with:
           apt-dependencies: 'pkg-config'
           cmake-args: '-DBUILDSYSTEM_TESTING=True'
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ include(IgnCMake)
 ign_configure_project()
 
 #--------------------------------------
+# Set project-specific options
+option(BUILDSYSTEM_TESTING "Enable extended buildsystem testing" FALSE)
+
+#--------------------------------------
 # Install the ignition documentation files
 # Note: This is not actually creating a doc target for ign-cmake; this is just
 # installing files that are useful for generating the documentation of other
@@ -148,7 +152,9 @@ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)
+endif()
 
+if (BUILD_TESTING AND BUILDSYSTEM_TESTING)
   #============================================================================
   # Build examples
   #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ### Ignition CMake 2.x.x
 
+1. Disable long-running buildsystem tests by default.
+    * [Pull request 97](https://github.com/ignitionrobotics/ign-cmake/pull/97)
 1. Set viewport for doxygen pages.
     * [BitBucket pull request 167](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-cmake/pull-requests/167)
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/bb/ignitionrobotics/ign-cmake/branch/default/graph/badge.svg)](https://codecov.io/bb/ignitionrobotics/ign-cmake)  
-Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci-default-bionic-amd64)](https://build.osrfoundation.org/job/ignition_cmake-ci-default-bionic-amd64)  
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci-default-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_cmake-ci-default-homebrew-amd64)  
+Test coverage | [![codecov](https://codecov.io/bb/ignitionrobotics/ign-cmake/branch/default/graph/badge.svg)](https://codecov.io/bb/ignitionrobotics/ign-cmake)
+Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci-default-bionic-amd64)](https://build.osrfoundation.org/job/ignition_cmake-ci-default-bionic-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci-default-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_cmake-ci-default-homebrew-amd64)
 Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-ci-default-windows7-amd64)](https://build.osrfoundation.org/job/ignition_cmake-ci-default-windows7-amd64)
 
 # Table of Contents
@@ -25,7 +25,7 @@ Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/ico
 * [Source Install](#source-install)
 
     * [Prerequisites](#prerequisites)
-  
+
     * [Building from Source](#building-from-source)
 
 [Usage](#usage)
@@ -102,9 +102,11 @@ Documentation for `ignition-cmake` can be found within the source code, and also
 
 # Testing
 
+A fuller suite of tests in the `examples` directory can be enabled by building with `BUILDSYSTEM_TESTING` enabled.
 Tests can be run by building the `test` target. From your build directory you can run:
 
 ```
+$ cmake .. -DBUILDSYSTEM_TESTING=1
 $ make test
 ```
 


### PR DESCRIPTION
From #92, this disables several tests that take a while to run and aren't correctly detected by CMake's change-detection.  This adds a new option `BUILDSYSTEM_TESTING`, which will re-enable these tests when true, and enables it in pipelines.

Tested locally with: 

```
$ cmake .. -DBUILDSYSTEM_TESTING=1
$ time make
make  81.50s user 23.50s system 99% cpu 1:45.22 total
```

```
$ cmake ..
$ time make
make  0.18s user 0.07s system 99% cpu 0.254 total
```

Depends on ignition-tooling/ubuntu-bionic-ci-action#9