### PR TITLE
Disable long-running buildsystem tests by default [ign-cmake2 backport]

### DIFF
--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -11,7 +11,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Bionic CI
         id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@master
+        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
         with:
           apt-dependencies: 'pkg-config'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+  bionic-ci-plus:
+    runs-on: ubuntu-latest
+    name: Ubuntu Bionic CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bionic CI
+        id: ci
+        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
+        with:
+          apt-dependencies: 'pkg-config'
+          cmake-args: '-DBUILDSYSTEM_TESTING=True'

--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -11,19 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Bionic CI
         id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
-        with:
-          apt-dependencies: 'pkg-config'
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
-  bionic-ci-plus:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Bionic CI
-        id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@cmake_args
+        uses: ignition-tooling/ubuntu-bionic-ci-action@master
         with:
           apt-dependencies: 'pkg-config'
           cmake-args: '-DBUILDSYSTEM_TESTING=True'
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ include(IgnCMake)
 ign_configure_project()
 
 #--------------------------------------
+# Set project-specific options
+option(BUILDSYSTEM_TESTING "Enable extended buildsystem testing" FALSE)
+
+#--------------------------------------
 # Install the ignition documentation files
 # Note: This is not actually creating a doc target for ign-cmake; this is just
 # installing files that are useful for generating the documentation of other
@@ -148,7 +152,9 @@ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)
+endif()
 
+if (BUILD_TESTING AND BUILDSYSTEM_TESTING)
   #============================================================================
   # Build examples
   #============================================================================

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/ico
 * [Source Install](#source-install)
 
     * [Prerequisites](#prerequisites)
-  
+
     * [Building from Source](#building-from-source)
 
 [Usage](#usage)
@@ -102,9 +102,11 @@ Documentation for `ignition-cmake` can be found within the source code, and also
 
 # Testing
 
+A fuller suite of tests in the `examples` directory can be enabled by building with `BUILDSYSTEM_TESTING` enabled.
 Tests can be run by building the `test` target. From your build directory you can run:
 
 ```
+$ cmake .. -DBUILDSYSTEM_TESTING=1
 $ make test
 ```
 


### PR DESCRIPTION
Backport #97 to ign-cmake2