### PR TITLE
[ign-cmake2] Disable long-running buildsystem tests by default (#97)

### DIFF
--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -14,4 +14,5 @@ jobs:
         uses: ignition-tooling/ubuntu-bionic-ci-action@master
         with:
           apt-dependencies: 'pkg-config'
+          cmake-args: '-DBUILDSYSTEM_TESTING=True'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ include(IgnCMake)
 ign_configure_project()
 
 #--------------------------------------
+# Set project-specific options
+option(BUILDSYSTEM_TESTING "Enable extended buildsystem testing" FALSE)
+
+#--------------------------------------
 # Install the ignition documentation files
 # Note: This is not actually creating a doc target for ign-cmake; this is just
 # installing files that are useful for generating the documentation of other
@@ -148,7 +152,9 @@ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)
+endif()
 
+if (BUILD_TESTING AND BUILDSYSTEM_TESTING)
   #============================================================================
   # Build examples
   #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition CMake 2.x
 
+### Ignition CMake 2.2.x
+
+1. Disable long-running buildsystem tests by default.
+    * [Pull request 97](https://github.com/ignitionrobotics/ign-cmake/pull/97)
+
 ### Ignition CMake 2.2.0
 
 1. Fix use of FindZIP without pkg-config.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Documentation for `ignition-cmake` can be found within the source code, and also
 
 # Testing
 
+A fuller suite of tests in the `examples` directory can be enabled by building with `BUILDSYSTEM_TESTING` enabled.
 Tests can be run by building the `test` target. From your build directory you can run:
 
 ```
+$ cmake .. -DBUILDSYSTEM_TESTING=1
 $ make test
 ```
 


### PR DESCRIPTION
Co-authored-by: Louise Poubel <louise@openrobotics.org>
Co-authored-by: Steve Peters <scpeters@openrobotics.org>
Co-authored-by: Louise Poubel <louise@openrobotics.org>
Signed-off-by: Michael Carroll <michael@openrobotics.org>