### PR TITLE
FindUUID: Export include path as expected by Ignition Libraries

### DIFF
--- a/cmake/FindUUID.cmake
+++ b/cmake/FindUUID.cmake
@@ -22,8 +22,36 @@ if (UNIX)
   if(NOT UUID_FOUND)
     include(IgnManualSearch)
     ign_manual_search(UUID
-                      HEADER_NAMES "uuid/uuid.h"
-                      LIBRARY_NAMES "uuid libuuid")
+                      HEADER_NAMES "uuid.h"
+                      LIBRARY_NAMES "uuid libuuid"
+                      PATH_SUFFIXES "uuid")
+  endif()
+
+  # The pkg-config or the manual search will place
+  # <uuid_install_prefix>/include/uuid in INTERFACE_INCLUDE_DIRECTORIES,
+  # but some projects exepect to use <uuid_install_prefix>/include, so
+  # we add it as well.
+  # See https://github.com/ignitionrobotics/ign-cmake/issues/103
+  if(TARGET UUID::UUID)
+    get_property(uuid_include_dirs
+      TARGET UUID::UUID
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+    set(uuid_include_dirs_extended ${uuid_include_dirs})
+
+    foreach(include_dir IN LISTS uuid_include_dirs)
+      if(include_dir MATCHES "uuid$")
+        get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
+        list(APPEND uuid_include_dirs_extended ${include_dir_parent})
+      endif()
+    endforeach()
+
+    list(REMOVE_DUPLICATES uuid_include_dirs_extended)
+
+    set_property(
+      TARGET UUID::UUID
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+      ${uuid_include_dirs_extended})
   endif()
 
   include(FindPackageHandleStandardArgs)

--- a/cmake/IgnManualSearch.cmake
+++ b/cmake/IgnManualSearch.cmake
@@ -17,12 +17,13 @@
 # ign_manual_search(<package> [INTERFACE]
 #     [HEADER_NAMES <header_names>]
 #     [LIBRARY_NAMES <library_names>]
-#     [TARGET_NAME <target_name>])
+#     [TARGET_NAME <target_name>]
+#     [PATH_SUFFIXES <path_suffixes>]])
 #
 # This macro will find a library based on the name of one of its headers,
 # and the library name.
-# It is used inside Find***.cmake scripts, typicall as fallback for a 
-# ign_pkg_check_modules_quiet call. 
+# It is used inside Find***.cmake scripts, typicall as fallback for a
+# ign_pkg_check_modules_quiet call.
 # It will create an imported target for the  library
 #
 # INTERFACE: Optional. Use INTERFACE when the target does not actually provide
@@ -38,13 +39,15 @@
 # TARGET_NAME: Optional. Explicitly specify the desired imported target name.
 #              Default is <package>::<package>.
 #
+# PATH_SUFFIXES: Optional. Parameter forwarded to the find_path and find_library calls.
+#
 macro(ign_manual_search package)
 
   #------------------------------------
   # Define the expected arguments
   set(options INTERFACE)
   set(oneValueArgs "TARGET_NAME")
-  set(multiValueArgs "HEADER_NAMES" "LIBRARY_NAMES")
+  set(multiValueArgs "HEADER_NAMES" "LIBRARY_NAMES" "PATH_SUFFIXES")
 
   #------------------------------------
   # Parse the arguments
@@ -59,7 +62,7 @@ macro(ign_manual_search package)
   if(NOT ign_manual_search_HEADER_NAMES)
     set(ign_manual_search_HEADER_NAMES "${package}.h")
   endif()
-  
+
   if(NOT ign_manual_search_LIBRARY_NAMES)
     set(ign_manual_search_LIBRARY_NAMES "${package}")
   endif()
@@ -67,14 +70,17 @@ macro(ign_manual_search package)
   if(NOT ign_manual_search_TARGET_NAME)
     set(ign_manual_search_TARGET_NAME "${package}::${package}")
   endif()
-  
+
   find_path(${package}_INCLUDE_DIRS
-            NAMES ${ign_manual_search_HEADER_NAMES})
+            NAMES ${ign_manual_search_HEADER_NAMES}
+            PATH_SUFFIXES ${ign_manual_search_PATH_SUFFIXES})
   find_library(${package}_LIBRARIES
-               NAMES ${ign_manual_search_LIBRARY_NAMES})
+               NAMES ${ign_manual_search_LIBRARY_NAMES}
+               PATH_SUFFIXES ${ign_manual_search_PATH_SUFFIXES})
+
   mark_as_advanced(${package}_INCLUDE_DIRS)
   mark_as_advanced(${package}_LIBRARIES)
-  
+
   set(${package}_FOUND true)
 
   if(NOT ${package}_INCLUDE_DIRS)


### PR DESCRIPTION
With this fix, UUID headers are correctly found even if UUID is not installed in a system prefix.

Fix https://github.com/ignitionrobotics/ign-cmake/issues/103 . 