### PR TITLE
FindFreeImage: find vcpkg's FreeImage on *nix

### DIFF
--- a/cmake/FindFreeImage.cmake
+++ b/cmake/FindFreeImage.cmake
@@ -73,7 +73,7 @@ if (NOT WIN32)
     endif(NOT FreeImage_INCLUDE_DIRS)
     mark_as_advanced(FreeImage_INCLUDE_DIRS)
 
-    find_library(FreeImage_LIBRARIES freeimage)
+    find_library(FreeImage_LIBRARIES NAMES freeimage FreeImage)
     if(FreeImage_LIBRARIES)
       set(FreeImage_FOUND true)
     else()


### PR DESCRIPTION
The `freeimage`  library installed by vcpkg is called `FreeImage` also on Linux and macOS, 
so to correctly find it is necessary to find both libraries called `freeimage` and libraries called
`FreeImage` also on Linux and macOS.