### PR TITLE
👩‍🌾⬆️ 2.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.3.0)
+project(ignition-cmake2 VERSION 2.4.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 ## Ignition CMake 2.x
 
+### Ignition CMake 2.X.X (20XX-XX-XX)
+
+### Ignition CMake 2.4.0 (2020-08-20)
+
+1. Added an option to include generated code in the ign_create_docs function
+    * [Pull request 108](https://github.com/ignitionrobotics/ign-cmake/pull/108)
+
 ### Ignition CMake 2.3.0 (2020-08-07)
 
 1. New macros to help with filter google-test in some platforms


### PR DESCRIPTION
I'd like to make a release to remove this warning from `ign-msgs` CI:

```
CMake Warning (dev) at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:1758 (message):
  

  The build script has specified some unrecognized arguments for
  ign_create_docs(~):

  
  AUTOGENERATED_DOC;/var/lib/jenkins/workspace/ignition_msgs-ci-ign-msgs4-bionic-amd64/build/include/ignition/msgs/


  Either the script has a typo, or it is using an unexpected version of
  ign-cmake.  The version of ign-cmake currently being used is 2.3.0
```

https://build.osrfoundation.org/job/ignition_msgs-ci-ign-msgs4-bionic-amd64/25/consoleFull