### PR TITLE
find_package fixes for TINYXML2 and ZeroMQ

### DIFF
--- a/cmake/FindTINYXML2.cmake
+++ b/cmake/FindTINYXML2.cmake
@@ -14,11 +14,21 @@
 # limitations under the License.
 #
 ########################################
-# Find tinyxml2. Only debian distributions package tinyxml with a pkg-config.
+# Find tinyxml2.
 
+# Try to find it in Config mode first
+find_package(TINYXML2 CONFIG QUIET NAMES tinyxml2)
+if(TINYXML2_FOUND)
+  message(STATUS "Found TINYXML2 via Config file: ${TINYXML2_DIR}")
+  # Create an "alias" target for tinyxml2::tinyxml2
+  add_library(TINYXML2::TINYXML2 INTERFACE IMPORTED)
+  target_link_libraries(TINYXML2::TINYXML2 INTERFACE tinyxml2::tinyxml2)
+  return()
+endif()
+
+# Use pkg_check_modules if the Config search fails.
+# Only debian distributions package tinyxml with a pkg-config.
 include(IgnPkgConfig)
-
-# Use pkg_check_modules to start
 ign_pkg_check_modules_quiet(TINYXML2 tinyxml2)
 
 # If that failed, then fall back to manual detection (necessary for MacOS)

--- a/cmake/FindZeroMQ.cmake
+++ b/cmake/FindZeroMQ.cmake
@@ -61,17 +61,9 @@ set(ZeroMQ_TARGET ZeroMQ::ZeroMQ)
 
 find_package(ZeroMQ ${ZeroMQ_FIND_VERSION} QUIET CONFIG)
 if (ZeroMQ_FOUND)
-
-  # ZeroMQ's cmake script imports its own target, so we'll
-  # overwrite the default with the name of theirs. In the
-  # future, we should be able to use a target alias instead.
-  set(ZeroMQ_TARGET libzmq)
-
   # Make sure to fill out the pkg-config information before quitting
   ign_pkg_config_entry(ZeroMQ "libzmq >= ${ZeroMQ_FIND_VERSION}")
-
   return()
-
 endif()
 
 if (UNIX)


### PR DESCRIPTION
This is similar to what `sdfomat` [has](https://github.com/osrf/sdformat/blob/d02105e8807645fa148c9bdd179468e8e7eb79a6/cmake/Modules/FindTinyXML2.cmake#L13). It particularly helps when using `tinyxml2` from Conan.