### PR TITLE
⬆️  2.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.4.0)
+project(ignition-cmake2 VERSION 2.5.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 ### Ignition CMake 2.X.X (20XX-XX-XX)
 
+### Ignition CMake 2.5.0 (2020-09-05)
+
+1. Add additional input directories to parse when generating documentation
+    * [Pull request 111](https://github.com/ignitionrobotics/ign-cmake/pull/111)
+
 ### Ignition CMake 2.4.0 (2020-08-20)
 
 1. Added an option to include generated code in the ign_create_docs function


### PR DESCRIPTION
Prepare for 2.5.0 release.

I thought we wouldn't need a release just for #111 because it only affects documentation. But it is causing warnings on our CI, so I think a quick release is in order.

```
CMake Warning (dev) at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:1758 (message):
  

  The build script has specified some unrecognized arguments for
  ign_create_docs(~):

  
  ADDITIONAL_INPUT_DIRS;/var/lib/jenkins/workspace/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/ign-gazebo/src/systems
  /var/lib/jenkins/workspace/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/ign-gazebo/src/gui/plugins


  Either the script has a typo, or it is using an unexpected version of
  ign-cmake.  The version of ign-cmake currently being used is 2.4.0

Call Stack (most recent call first):
  /usr/share/cmake/ignition-cmake2/cmake2/IgnCreateDocs.cmake:50 (_ign_cmake_parse_arguments)
  CMakeLists.txt:164 (ign_create_docs)
This warning is for project developers.  Use -Wno-dev to suppress it.
```