### PR TITLE
Fix FindIgnOgre on Windows when not using vcpkg

### DIFF
--- a/cmake/FindIgnOGRE.cmake
+++ b/cmake/FindIgnOGRE.cmake
@@ -178,7 +178,7 @@ else()
         set(prefix "")
 	# vcpkg uses special directory (lib/manual-link/) to place libraries
 	# with main sysmbol like OgreMain.
-	if(ogre_lib MATCHES "OgreMain" AND NOT IS_ABSOLUTE "${ogre_lib}")
+	if(ogre_lib MATCHES "OgreMain" AND NOT IS_ABSOLUTE "${ogre_lib}" AND EXISTS "${OGRE_LIBRARY_DIRS}/manual-link/")
           set(prefix "${OGRE_LIBRARY_DIRS}/manual-link/")
 	elseif(ogre_lib MATCHES "Ogre" AND NOT IS_ABSOLUTE "${ogre_lib}")
           set(prefix "${OGRE_LIBRARY_DIRS}/")


### PR DESCRIPTION
The current version of FindIgnOgre contains a vcpkg-specific workaround on the location of the OgreMain library, that is fixed to point to the "${OGRE_LIBRARY_DIRS}/manual-link/" directory, that it is its location when Ogre is installed by vcpkg. 

However, this creates a problem when installing Ogre with other package managers  on Windows, for example when using conda-forge or conan. To mitigate this problem, we only set the location of the OgreMain library to be "${OGRE_LIBRARY_DIRS}/manual-link/" only if this directory exists, that is only true for vcpkg installations.