### PR TITLE
FindIgnOGRE2: prefer versioned component libraries

### DIFF
--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -211,7 +211,11 @@ if (NOT WIN32)
   # find ogre components
   include(IgnImportTarget)
   foreach(component ${IgnOGRE2_FIND_COMPONENTS})
-    find_library(OGRE2-${component} NAMES "Ogre${component}" HINTS ${OGRE2_LIBRARY_DIRS})
+    find_library(OGRE2-${component}
+      NAMES
+        "Ogre${component}.${OGRE2_VERSION}"
+        "Ogre${component}"
+      HINTS ${OGRE2_LIBRARY_DIRS})
     if (NOT "OGRE2-${component}" STREQUAL "OGRE2-${component}-NOTFOUND")
 
       # create a new target for each component


### PR DESCRIPTION
Both ogre1.9 and ogre2.1 install component libraries named
libOgreOverlay. For ogre1.9, an unversioned symbolic link is
installed directly into the lib folder, while in our debian
libogre-2.1-dev and brew ogre2.1 packages, an unversioned symbolic
link is installed in lib/OGRE-2.1.

This find module uses find_library to find Ogre component libraries
with HINTS pointing to the lib/OGRE-2.1 subfolder, which is helpful
but limited because the CMAKE_PREFIX_PATH is searched before
the HINTS. When building ignition-rendering with homebrew, the
CMAKE_PREFIX_PATH may include /usr/local, which causes the
libOgreOverlay library from ogre1.9 to be found before the
version from ogre2.1.

On macOS, the following are in /usr/local/lib:

    /usr/local/lib/libOgreOverlay.1.9.0.dylib
    /usr/local/lib/libOgreOverlay.2.1.0.dylib
    /usr/local/lib/libOgreOverlay.dylib (sym-link to 1.9.0)

This causes find_library to prefer a library name with the version
appended before the suffix, while still accepting unversioned names
if a versioned name is not found.

I believe this will fix https://github.com/ignitionrobotics/ign-sensors/issues/62