### PR TITLE
Update packages.apt

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,1 +1,3 @@
+build-essential
+cmake
 pkg-config


### PR DESCRIPTION
A lot of the Ignition repositories are transitioning towards instructing users to use a repository's `*packages.apt` files to install build dependencies (for example, [ign-gazebo](https://github.com/ignitionrobotics/ign-gazebo/blob/53f7bdb98b9654d02662df1d7606103a6366f507/README.md#source-install)). In case users want to install all of the Ignition build dependencies in a single pass via a command like [this](https://github.com/ignition-tooling/setup-ign-docker/blob/03558a291a4221770cd8d5025a232f0cf14a4f1f/setup-ign.sh#L113-L118), we should make sure things like `cmake` (and `make`) get installed so that users have no issues when using `ign-cmake`.

I also added in `build-essential` because this will guarantee that `gcc`, `g++`, and `make` are installed on Ubuntu Bionic and Focal - this is important in case users decided to use the `--no-install-recommends` flag when installing packages listed in the `*packages.apt` files (I ran a test with the [`ubuntu:focal` Docker image](https://hub.docker.com/layers/ubuntu/library/ubuntu/focal/images/sha256-4e4bc990609ed865e07afc8427c30ffdddca5153fd4e82c20d8f0783a291e241?context=explore) and noticed that `make` wasn't installed even after installing all Ignition Binaries and other packages in Ignition's `*packages.apt` files. Including `build-essential` fixed this for me):
```
adl-ws@96bdcbfc1916:~/ws$ apt-cache depends build-essential
build-essential
 |Depends: libc6-dev
  Depends: <libc-dev>
    libc6-dev
  Depends: gcc
  Depends: g++
  Depends: make
    make-guile
  Depends: dpkg-dev
```

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>