### PR TITLE
Revert python to optional dependency

### DIFF
--- a/cmake/IgnCodeCheck.cmake
+++ b/cmake/IgnCodeCheck.cmake
@@ -40,12 +40,15 @@ function(ign_setup_target_for_codecheck)
     COMMAND ${CPPCHECK_PATH} ${CPPCHECK_BASE} --enable=missingInclude `${CPPCHECK_FIND}`
   )
 
-  add_custom_target(cpplint
-    # cpplint cppcheck
-    COMMAND ${PYTHON_EXECUTABLE} ${IGNITION_CMAKE_CODECHECK_DIR}/cpplint.py --extensions=cc,hh --quiet `${CPPCHECK_FIND}`
+  add_custom_target(codecheck
+    DEPENDS cppcheck
   )
 
-  add_custom_target(codecheck
-    DEPENDS cpplint cppcheck
-  )
+  if(PYTHONINTERP_FOUND)
+    add_custom_target(cpplint
+      COMMAND ${PYTHON_EXECUTABLE} ${IGNITION_CMAKE_CODECHECK_DIR}/cpplint.py --extensions=cc,hh --quiet `${CPPCHECK_FIND}`
+    )
+
+    add_dependencies(codecheck cpplint)
+  endif()
 endfunction()

--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -22,4 +22,4 @@ if(NOT PYTHON_VERSION)
   set(PYTHON_VERSION "3")
 endif()
 
-find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+find_package(PythonInterp ${PYTHON_VERSION} QUIET)


### PR DESCRIPTION
The homebrew update for ignition-cmake 2.6.0 (osrf/homebrew-simulation#1222) has a failing bottle build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_mojave&build=124)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_mojave/124/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_mojave/124/

It complains about being unable to find Python3. Prior to #117, there was a `find_package(PythonInterp QUIET)` call in `ign_build_tests` when setting up the `check_test_ran.py` test, but that was changed to `REQUIRED`. This reverts that change to restore python to an optional dependency and disables the `cpplint` portion of `make codecheck` if python is not available. We are already checking if python is found before [using the `check_test_ran.py` script](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/cmake/IgnUtils.cmake#L1699).

The alternative to to make python3 a required dependency, which will require updates to the documentation and packaging metadata.