### PR TITLE
Generate valid visibility macros by replacing hyphens in component name

### DIFF
--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -1103,6 +1103,8 @@ function(ign_add_component component_name)
   # Create an upper case version of the component name, to be used as an export
   # base name.
   string(TOUPPER ${component_name} component_name_upper)
+  # hyphen is not supported as macro name, replace it by underscore
+  string(REPLACE "-" "_" component_name_upper ${component_name_upper})
 
   #------------------------------------
   # Create the target for this component, and configure it to be installed
@@ -1347,6 +1349,14 @@ macro(_ign_add_library_or_component)
     set(export_base ${_ign_add_library_EXPORT_BASE})
   else()
     _ign_add_library_or_component_arg_error(EXPORT_BASE)
+  endif()
+
+  # check that export_base has no invalid symbols
+  string(REPLACE "-" "_" export_base_replaced ${export_base})
+  if(NOT ${export_base} STREQUAL ${export_base_replaced})
+      message(FATAL_ERROR
+        "export_base has a hyphen which is not"
+        "supported by macros used for visibility")
   endif()
 
   #------------------------------------


### PR DESCRIPTION
For cases where `ign_add_component` is being called using a name with hyphens, ign-cmake will generate a visibility macro using the hyphens, which is an [invalid character](https://stackoverflow.com/a/369524). The PR changes two things:

 * Safety internal check to error on presence of hyphens
 * Patch `_ign_add_library_or_component` to replace the hyphens by underscores

If you want to see the problem in action, create a colcon workspace for ign-gazebo and use the `win` branch. [This is the kind](https://build.osrfoundation.org/job/ignition_gazebo-abichecker-any_to_any-ubuntu_auto-amd64/2763/consoleFull#19523942916ea37b8d-a6d4-40ae-8431-d90c018842af) of error it generates:

```
In file included from /tmp/ign-gazebo/src/systems/air_pressure/AirPressure.hh:22,
                 from /tmp/ign-gazebo/src/systems/air_pressure/AirPressure.cc:18:
/var/lib/jenkins/workspace/ignition_gazebo-abichecker-any_to_any-ubuntu_auto-amd64/build/include/ignition/gazebo/air-pressure-system/Export.hh:25:28: warning: extra tokens at end of #ifndef directive
 #ifndef IGNITION_GAZEBO_AIR-PRESSURE-SYSTEM_EXPORT_HH_
                            ^
/var/lib/jenkins/workspace/ignition_gazebo-abichecker-any_to_any-ubuntu_auto-amd64/build/include/ignition/gazebo/air-pressure-system/Export.hh:26:28: warning: ISO C++11 requires whitespace after the macro name
 #define IGNITION_GAZEBO_AIR-PRESSURE-SYSTEM_EXPORT_HH_
```

