### PR TITLE
Remove deprecated doxygen configurations

### DIFF
--- a/doc/doxygen/api.in
+++ b/doc/doxygen/api.in
@@ -2109,12 +2109,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2127,15 +2121,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = NO
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The


### PR DESCRIPTION
On `focal`, we get warnings like:

```
--- stderr: ignition-utils0                              
warning: Tag 'PERL_PATH' at line 2116 of file '/home/mjcarroll/workspaces/ign_edifice/build/ignition-utils0/api_tagfile.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'MSCGEN_PATH' at line 2138 of file '/home/mjcarroll/workspaces/ign_edifice/build/ignition-utils0/api_tagfile.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'PERL_PATH' at line 2116 of file '/home/mjcarroll/workspaces/ign_edifice/build/ignition-utils0/api.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'MSCGEN_PATH' at line 2138 of file '/home/mjcarroll/workspaces/ign_edifice/build/ignition-utils0/api.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
---
```

This removes the deprecated lines.