### PR TITLE
Fix codeownders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # More info:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*      @mxgrey
-*      @adlarkin
-*      @j-rivero
+*      @mxgrey @adlarkin @j-rivero


### PR DESCRIPTION
I made a mistake in #151 by mentioning codeowners across separate lines, resulting in the last codeowner taking precedence for notifications/review requests (more information about how CODEOWNERS files work can be found [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file)). This PR places all codeowners on the same line so that all codeowners are notified/requested for review on new PRs.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
