### PR TITLE
Fix cmake message types

### DIFF
--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -46,19 +46,19 @@ macro(ign_configure_build)
   #============================================================================
   # Print warnings and errors
   if(build_warnings)
-    message("-- BUILD WARNINGS")
+    message(WARNING "-- BUILD WARNINGS")
     foreach (msg ${build_warnings})
-      message("-- ${msg}")
+      message(WARNING "-- ${msg}")
     endforeach ()
-    message("-- END BUILD WARNINGS\n")
+    message(WARNING "-- END BUILD WARNINGS\n")
   endif (build_warnings)
 
   if(build_errors)
-    message("-- BUILD ERRORS: These must be resolved before compiling.")
+    message(SEND_ERROR "-- BUILD ERRORS: These must be resolved before compiling.")
     foreach(msg ${build_errors})
-      message("-- ${msg}")
+      message(SEND_ERROR "-- ${msg}")
     endforeach()
-    message("-- END BUILD ERRORS\n")
+    message(SEND_ERROR "-- END BUILD ERRORS\n")
 
     set(error_str "Errors encountered in build. Please see BUILD ERRORS above.")
 


### PR DESCRIPTION
# 🦟 Bug fix

Same fix as https://github.com/ignitionrobotics/ign-tools/pull/41

## Summary

Print CMake errors with SEND_ERROR type, and warnings with WARNING type.

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
