### PR TITLE
Fix hardcoded pkg-config library in examples to fix tests on non-Debian Linux systems

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(ExternalProject)
+include(GNUInstallDirs)
 
 # test multiple build types
 set(build_types Release RelWithDebInfo Debug)
@@ -174,7 +175,16 @@ if (UNIX)
     "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}_fail.xml"
     @ONLY)
   set(_env_vars)
-  list(APPEND _env_vars "PKG_CONFIG_PATH=${example_INSTALL_DIR}/lib/pkgconfig:${FAKE_INSTALL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH")
+  # On Debian and if the install prefix is /usr, the default CMAKE_INSTALL_LIBDIR of this project
+  # as set by GNUInstallDirs will be different from the one of the example project, 
+  # so let's hardcode it in that case
+  if(EXISTS "/etc/debian_version" AND "${CMAKE_INSTALL_PREFIX}" MATCHES "^/usr/?$")
+    set(example_PKGCONFIG_INSTALL_LIBDIR "lib/pkgconfig")
+  else()
+    set(example_PKGCONFIG_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  endif()
+
+  list(APPEND _env_vars "PKG_CONFIG_PATH=${example_INSTALL_DIR}/${example_PKGCONFIG_INSTALL_LIBDIR}:${FAKE_INSTALL_PREFIX}/${example_PKGCONFIG_INSTALL_LIBDIR}:$PKG_CONFIG_PATH")
   add_test(${TEST_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/test_core_child_requires_core_no_deps.bash
   )


### PR DESCRIPTION
# 🦟 Bug fix

Fixes test failures on platforms (such as non-Debian Linux) in which `CMAKE_INSTALL_LIBDIR` is not equal to `lib`.

## Summary

 ignition-cmake by default installs the pkg-config files in `${CMAKE_INSTALL_LIBDIR}\pkgconfig` (see https://github.com/ignitionrobotics/ign-cmake/blob/b03ca34191e538d334f8d9bb285711a4b487e2a4/cmake/IgnPackaging.cmake#L201). Later, in the tests before this PR it is assumed that they are installed by default in `lib\pkgconfig`. However, there are several platforms (such as a any non-Debian Linux system) in which `${CMAKE_INSTALL_LIBDIR}` is not `lib`, so in those platforms the test would fail.

This PR fixes this by using `${CMAKE_INSTALL_LIBDIR}` also in the tests.

## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**