### PR TITLE
👩‍🌾 ign_find_package: respect QUIET

### DIFF
--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -46,8 +46,8 @@
 #          <project>-config.cmake file.
 #
 # [QUIET]: Optional. If provided, it will be passed forward to cmake's
-#          find_package(~) command. This macro will still print its normal
-#          output.
+#          find_package(~) command. It also suppresses warnings emitted by this
+#          macro.
 #
 # [BUILD_ONLY]: Optional. Use this to indicate that the project only needs this
 #               package while building, and it does not need to be available to
@@ -221,7 +221,9 @@ macro(ign_find_package PACKAGE_NAME)
 
         # Otherwise, if it was only required by some of the components, create
         # a warning about which components will not be available.
-        ign_build_warning("Cannot build component [${component}] - ${${PACKAGE_NAME}_msg}")
+        if(NOT ign_find_package_QUIET)
+          ign_build_warning("Cannot build component [${component}] - ${${PACKAGE_NAME}_msg}")
+        endif()
 
         # Also create a variable to indicate that we should skip the component
         set(SKIP_${component} true)
@@ -231,7 +233,9 @@ macro(ign_find_package PACKAGE_NAME)
       endforeach()
 
     else()
-      ign_build_warning(${${PACKAGE_NAME}_msg})
+      if(NOT ign_find_package_QUIET)
+        ign_build_warning(${${PACKAGE_NAME}_msg})
+      endif()
     endif()
 
   endif()


### PR DESCRIPTION
## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is meant to help with https://github.com/ignitionrobotics/ign-rendering/issues/281.

Judging by the documentation, I believe `QUIET` wasn't being used to suppress warnings from the macro on purpose. But I can't think of a reason not to use that argument :thinking: 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/181
