### PR TITLE
User-friendly skip component warning

### DIFF
--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -46,11 +46,11 @@ macro(ign_configure_build)
   #============================================================================
   # Print warnings and errors
   if(build_warnings)
-    message(WARNING "-- BUILD WARNINGS")
+    set(all_warnings " BUILD WARNINGS:")
     foreach (msg ${build_warnings})
-      message(WARNING "-- ${msg}")
+      ign_string_append(all_warnings " -- ${msg}" DELIM "\n")
     endforeach ()
-    message(WARNING "-- END BUILD WARNINGS\n")
+    message(WARNING "${all_warnings}")
   endif (build_warnings)
 
   if(build_errors)

--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -46,7 +46,7 @@ macro(ign_configure_build)
   #============================================================================
   # Print warnings and errors
   if(build_warnings)
-    set(all_warnings " BUILD WARNINGS:")
+    set(all_warnings " CONFIGURATION WARNINGS:")
     foreach (msg ${build_warnings})
       ign_string_append(all_warnings " -- ${msg}" DELIM "\n")
     endforeach ()

--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -191,7 +191,7 @@ macro(ign_configure_build)
     # Add the source code directories of each component if they exist
     foreach(component ${ign_configure_build_COMPONENTS})
 
-      if(NOT SKIP_${component})
+      if(NOT SKIP_${component} AND NOT INTERNAL_SKIP_${component})
 
         set(found_${component}_src FALSE)
 
@@ -255,7 +255,9 @@ macro(ign_configure_build)
       else()
 
         set(skip_msg "Skipping the component [${component}]")
-        if(${component}_MISSING_DEPS)
+        if(SKIP_${component})
+          ign_string_append(skip_msg "by user request")
+        elseif(${component}_MISSING_DEPS)
           ign_string_append(skip_msg "because the following packages are missing: ${${component}_MISSING_DEPS}")
         endif()
 

--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -47,7 +47,8 @@
 #
 # [QUIET]: Optional. If provided, it will be passed forward to cmake's
 #          find_package(~) command. This macro will still print its normal
-#          output.
+#          output, except there will be no warning if the package is missing,
+#          unless REQUIRED or REQUIRED_BY is specified.
 #
 # [BUILD_ONLY]: Optional. Use this to indicate that the project only needs this
 #               package while building, and it does not need to be available to

--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -223,9 +223,7 @@ macro(ign_find_package PACKAGE_NAME)
           # Otherwise, if it was only required by some of the components, create
           # a warning about which components will not be available, unless the
           # user explicitly requested that it be skipped
-          ign_build_warning(
-            "Skipping component [${component}]: ${${PACKAGE_NAME}_msg}. "
-            "Set SKIP_${component}=true in cmake to suppress this warning.")
+          ign_build_warning("Skipping component [${component}]: ${${PACKAGE_NAME}_msg}.\n    ^~~~~ Set SKIP_${component}=true in cmake to suppress this warning.\n ")
 
           # Create a variable to indicate that we need to skip the component
           set(INTERNAL_SKIP_${component} true)
@@ -779,8 +777,7 @@ endmacro(ign_build_error)
 # ign_build_warning macro
 macro(ign_build_warning)
   foreach(str ${ARGN})
-    set(msg "\t${str}" )
-    list(APPEND build_warnings ${msg})
+    list(APPEND build_warnings "${str}")
   endforeach(str ${ARGN})
 endmacro(ign_build_warning)
 

--- a/tutorials/developing_with_ign-cmake.md
+++ b/tutorials/developing_with_ign-cmake.md
@@ -36,6 +36,35 @@ To change the build type, set the CMake flag:
 -DCMAKE_BUILD_TYPE=Debug
 ```
 
+### Disabling or suppressing warnings about optional components
+
+Many ignition packages come with optional component libraries.
+These optional components will typically have additional dependencies that the
+package's core library does not require. If you are missing the dependencies of
+any optional components, you will receive a cmake warning like
+
+```
+-- Skipping component [component_name]: Missing dependency [dependency_name].
+   ^~~~~ Set SKIP_component_name=true in cmake to suppress this warning.
+```
+
+If you do not care about the specified component, you can safely ignore this
+warning. The configuration and build steps will succeed without any problem. The
+only side effect is the optional component will not be built.
+
+If you do want to build the optional component, then you will need to install
+whichever dependencies were said to be missing and then rerun cmake.
+
+If you do *not* want to build the optional component and you want to suppress
+the warning about the missing dependencies, you can set the cmake flag:
+
+```
+-DSKIP_component_name=true
+```
+
+where you should replace `component_name` with the actual name of the component
+as specified inside the angle brackets `[]` of the warning.
+
 ### Creating a compilation database
 
 `CMake` can optionally generate a compilation data base that may be used with a variety of code completion tools.


### PR DESCRIPTION
## Summary

This is an alternative proposal for #164.

The idea here is that `ign-cmake` assumes users *might* want to build all optional components unless the user explicitly specifies `SKIP_<component>` to cmake. We allow the configuration to succeed even if optional components need to be skipped due to missing dependencies, but we issue a clear (but friendly) warning to the user about which optional components will be skipped and why they are being skipped. We also provide an instruction for how to suppress the warning in case they find it bothersome.

I recommend we issue warnings rather than status messages because status messages are easily overlooked, especially when building with `colcon` whose default behavior is to send all status messages into the build log instead of displaying them to users. We provide a straightforward way to suppress these warnings, so users who don't like them can easily turn them off. Also this PR modifies the tone of the warning so no one should be left with the impression that their configuration is broken due to optional components being skipped.

As a side-effect this PR also cleans up the way warnings are displayed to users. It turns out cmake's rules for formatting messages are [rather complex](https://stackoverflow.com/a/51035045), and our approach to generating the warning messages was creating a lot more noise than we intended. 

Here's an example of someone configuring `ign-rendering4` off of this PR when they are missing the dependencies of `ignition-rendering-optix` and `ignition-rendering-ogre2`:

```
   CONFIGURATION WARNINGS:
   -- Skipping component [ogre2]: Missing dependency [IgnOGRE2] (Components: HlmsPbs, HlmsUnlit, Overlay).
      ^~~~~ Set SKIP_ogre2=true in cmake to suppress this warning.

   -- Skipping component [optix]: Missing dependency [OptiX].
      ^~~~~ Set SKIP_optix=true in cmake to suppress this warning
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
