### PR TITLE
Fix building OGRE / OGRE2 from source in colcon workspace

### DIFF
--- a/cmake/FindIgnOGRE.cmake
+++ b/cmake/FindIgnOGRE.cmake
@@ -83,6 +83,16 @@ if (NOT WIN32)
 
   # loop through pkg config paths and find an ogre version that is < 2.0.0
   foreach(pkg_path ${PKG_CONFIG_PATH_TMP})
+
+    if (NOT EXISTS ${pkg_path})
+      continue()
+    endif()
+
+    unset(OGRE_FOUND)
+    unset(OGRE_INCLUDE_DIRS)
+    unset(OGRE_LIBRARY_DIRS)
+    unset(OGRE_LIBRARIES)
+
     set(ENV{PKG_CONFIG_PATH} ${pkg_path})
     ign_pkg_check_modules_quiet(OGRE "OGRE >= ${full_version}"
                                 NO_CMAKE_ENVIRONMENT_PATH
@@ -91,6 +101,31 @@ if (NOT WIN32)
       if (NOT ${OGRE_VERSION} VERSION_LESS 2.0.0)
         set (OGRE_FOUND false)
       else ()
+        # set library dirs if the value is empty
+        if (NOT ${OGRE_LIBRARY_DIRS} OR ${OGRE_LIBRARY_DIRS} STREQUAL "")
+          execute_process(COMMAND pkg-config --variable=libdir OGRE
+                          OUTPUT_VARIABLE _pkgconfig_invoke_result
+                          RESULT_VARIABLE _pkgconfig_failed)
+          if(_pkgconfig_failed)
+            IGN_BUILD_WARNING ("Failed to find OGRE's library directory.  The build will succeed, but there will likely be run-time errors.")
+          else()
+            # set ogre library dir and strip line brak
+            set(OGRE_LIBRARY_DIRS ${_pkgconfig_invoke_result})
+            string(REGEX REPLACE "\n$" "" OGRE_LIBRARY_DIRS "${OGRE_LIBRARY_DIRS}")
+
+            string(FIND "${OGRE_LIBRARIES}" "${OGRE_LIBRARY_DIRS}" substr_found)
+            # in some cases the value of OGRE_LIBRARIES is "OgreMain;pthread"
+            # Convert this to full path to library
+            if (substr_found EQUAL -1)
+              foreach(OGRE_LIBRARY_NAME ${OGRE_LIBRARIES})
+                find_library(OGRE_LIBRARY NAMES ${OGRE_LIBRARY_NAME}
+                             HINTS ${OGRE_LIBRARY_DIRS} NO_DEFAULT_PATH)
+                list (APPEND TMP_OGRE_LIBRARIES "${OGRE_LIBRARY}")
+              endforeach()
+              set(OGRE_LIBRARIES ${TMP_OGRE_LIBRARIES})
+            endif()
+          endif()
+        endif()
         break()
       endif()
     endif()
@@ -107,9 +142,10 @@ if (NOT WIN32)
 
     # find ogre components
     foreach(component ${IgnOGRE_FIND_COMPONENTS})
-      ign_pkg_check_modules_quiet(IgnOGRE-${component} "OGRE-${component} >= ${full_version}")
+      ign_pkg_check_modules_quiet(IgnOGRE-${component} "OGRE-${component} >= ${full_version}" NO_CMAKE_ENVIRONMENT_PATH)
       if(IgnOGRE-${component}_FOUND)
         list(APPEND OGRE_LIBRARIES IgnOGRE-${component}::IgnOGRE-${component})
+
       elseif(IgnOGRE_FIND_REQUIRED_${component})
         set(OGRE_FOUND false)
       endif()

--- a/cmake/FindIgnOGRE.cmake
+++ b/cmake/FindIgnOGRE.cmake
@@ -69,7 +69,7 @@ if (NOT WIN32)
                   RESULT_VARIABLE _pkgconfig_failed)
   if(_pkgconfig_failed)
     IGN_BUILD_WARNING ("Failed to get pkg-config search paths")
-  elseif (NOT "_pkgconfig_invoke_result" STREQUAL "")
+  elseif (NOT _pkgconfig_invoke_result STREQUAL "")
     set (PKG_CONFIG_PATH_TMP "${PKG_CONFIG_PATH_TMP}:${_pkgconfig_invoke_result}")
   endif()
 
@@ -83,16 +83,13 @@ if (NOT WIN32)
 
   # loop through pkg config paths and find an ogre version that is < 2.0.0
   foreach(pkg_path ${PKG_CONFIG_PATH_TMP})
-
     if (NOT EXISTS ${pkg_path})
       continue()
     endif()
-
-    unset(OGRE_FOUND)
-    unset(OGRE_INCLUDE_DIRS)
-    unset(OGRE_LIBRARY_DIRS)
-    unset(OGRE_LIBRARIES)
-
+    set(OGRE_FOUND false)
+    set(OGRE_INCLUDE_DIRS "")
+    set(OGRE_LIBRARY_DIRS "")
+    set(OGRE_LIBRARIES "")
     set(ENV{PKG_CONFIG_PATH} ${pkg_path})
     ign_pkg_check_modules_quiet(OGRE "OGRE >= ${full_version}"
                                 NO_CMAKE_ENVIRONMENT_PATH
@@ -109,7 +106,7 @@ if (NOT WIN32)
           if(_pkgconfig_failed)
             IGN_BUILD_WARNING ("Failed to find OGRE's library directory.  The build will succeed, but there will likely be run-time errors.")
           else()
-            # set ogre library dir and strip line brak
+            # set ogre library dir and strip line break
             set(OGRE_LIBRARY_DIRS ${_pkgconfig_invoke_result})
             string(REGEX REPLACE "\n$" "" OGRE_LIBRARY_DIRS "${OGRE_LIBRARY_DIRS}")
 
@@ -145,7 +142,6 @@ if (NOT WIN32)
       ign_pkg_check_modules_quiet(IgnOGRE-${component} "OGRE-${component} >= ${full_version}" NO_CMAKE_ENVIRONMENT_PATH)
       if(IgnOGRE-${component}_FOUND)
         list(APPEND OGRE_LIBRARIES IgnOGRE-${component}::IgnOGRE-${component})
-
       elseif(IgnOGRE_FIND_REQUIRED_${component})
         set(OGRE_FOUND false)
       endif()

--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -110,7 +110,7 @@ if (NOT WIN32)
                     RESULT_VARIABLE _pkgconfig_failed)
     if(_pkgconfig_failed)
       IGN_BUILD_WARNING ("Failed to get pkg-config search paths")
-    elseif (NOT "_pkgconfig_invoke_result" STREQUAL "")
+    elseif (NOT _pkgconfig_invoke_result STREQUAL "")
       set (PKG_CONFIG_PATH_TMP "${PKG_CONFIG_PATH_TMP}:${_pkgconfig_invoke_result}")
     endif()
 

--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -275,6 +275,15 @@ if (NOT WIN32)
 
 else() #WIN32
   # reset ogre variables to be sure they dont conflict with OGRE1
+  # todo(anyone) May need to change this to set(<variable> "")
+  # and verify that it works on Windows.
+  # More info: when evaluating Variable References of the form ${VAR}, CMake
+  # first searches for a normal variable with that name. If no such normal
+  # variable exists, CMake will then search for a cache entry with that name.
+  # Because of this unsetting a normal variable can expose a cache variable
+  # that was previously hidden. To force a variable reference of the form ${VAR}
+  # to return an empty string, use set(<variable> ""), which clears the normal
+  # variable but leaves it defined.
   unset(OGRE_FOUND)
   unset(OGRE_INCLUDE_DIRS)
   unset(OGRE_LIBRARIES)

--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -217,6 +217,8 @@ if (NOT WIN32)
   foreach(component ${IgnOGRE2_FIND_COMPONENTS})
     find_library(OGRE2-${component}
       NAMES
+        "Ogre${component}_d.${OGRE2_VERSION}"
+        "Ogre${component}_d"
         "Ogre${component}.${OGRE2_VERSION}"
         "Ogre${component}"
       HINTS ${OGRE2_LIBRARY_DIRS})


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Problem: When building [ogre2](https://github.com/ignition-forks/ogre-2.1-release) in a colcon workspace, we ran into an error about not finding an ogre **1.x** component. The problem is the cmake module for ogre 1.x is looking into the ogre2 source directory in the colcon workspace instead of the system installed one. 

I also had to fix the values returned by the `OGRE_LIBRARIES` variable. It needs to be the full path to the library. We are actually doing something similar [ogre2 cmake module](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/cmake/FindIgnOGRE2.cmake#L134) and also [in the logic for ogre 1.x on windows](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/cmake/FindIgnOGRE.cmake#L166). Not sure why the issue only surfaced in the colcon workspace setup mentioned above.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
