### PR TITLE
Fix problems on IgnOGRE when version is not found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ### Ignition CMake 2.X.X (20XX-XX-XX)
 
+1. Fix problems on IgnOGRE.cmake when version is not found
+
 ### Ignition CMake 2.8.0 (2021-04-30)
 
 1. Fix hardcoded pkg-config library in examples

--- a/cmake/FindIgnOGRE.cmake
+++ b/cmake/FindIgnOGRE.cmake
@@ -236,23 +236,24 @@ else()
     set(OGRE_LIBRARIES ${ogre_all_libs})
     set(OGRE_RESOURCE_PATH ${OGRE_CONFIG_DIR})
   endif()
-endif()
 
-# manually search and append the the RenderSystem/GL path to
-# OGRE_INCLUDE_DIRS so OGRE GL headers can be found
-foreach (dir ${OGRE_INCLUDE_DIRS})
-  get_filename_component(dir_name "${dir}" NAME)
-  if("${dir_name}" STREQUAL "OGRE")
-    if(${OGRE_VERSION} VERSION_LESS 1.11.0)
-      set(dir_include "${dir}/RenderSystems/GL")
+  # manually search and append the the RenderSystem/GL path to
+  # OGRE_INCLUDE_DIRS so OGRE GL headers can be found
+  foreach(dir ${OGRE_INCLUDE_DIRS})
+    get_filename_component(dir_name "${dir}" NAME)
+    if("${dir_name}" STREQUAL "OGRE")
+      if(${OGRE_VERSION} VERSION_LESS 1.11.0)
+        set(dir_include "${dir}/RenderSystems/GL")
+      else()
+        set(dir_include "${dir}/RenderSystems/GL" "${dir}/Paging")
+      endif()
     else()
-      set(dir_include "${dir}/RenderSystems/GL" "${dir}/Paging")
+      set(dir_include "${dir}")
     endif()
-  else()
-    set(dir_include "${dir}")
-  endif()
-  list(APPEND OGRE_INCLUDE_DIRS ${dir_include})
-endforeach()
+    list(APPEND OGRE_INCLUDE_DIRS ${dir_include})
+  endforeach()
+
+endif()
 
 set(IgnOGRE_FOUND false)
 if(OGRE_FOUND)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

When Ogre is not found (looking for 1.10 in a 1.9 environment), the builds fail with:

```cmake
CMake Error at /usr/share/cmake/ignition-cmake2/cmake2/FindIgnOGRE.cmake:214 (if):
  if given arguments:

    "VERSION_LESS" "1.11.0"

  Unknown arguments specified
Call Stack (most recent call first):
  /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:189 (find_package)
  CMakeLists.txt:69 (ign_find_package)


-- Configuring incomplete, errors occurred!
```

There is a final block starting at line 240 that is not protected by the check of `OGRE_FOUND` leaving `OGRE_VERSION` empty and making the whole thing to crash. I did not find any reason not to include it under `OGRE_FOUND`.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**