### PR TITLE
Prepare for 2.10.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.9.0)
+project(ignition-cmake2 VERSION 2.10.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake
@@ -20,7 +20,7 @@ include(IgnCMake)
 
 #--------------------------------------
 # Set up the project
-ign_configure_project(VERSION_SUFFIX)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #--------------------------------------
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,21 @@
 ## Ignition CMake 2.x
 
-### Ignition CMake 2.X.X (2021-XX-XX)
+### Ignition CMake 2.10.0 (2021-12-09)
+
+1. Add Ubuntu Jammy CI
+    * [Pull request #194](https://github.com/ignitionrobotics/ign-cmake/pull/194)
+
+1. FindIgnURDFDOM cmake module
+    * [Pull request #193](https://github.com/ignitionrobotics/ign-cmake/pull/193)
+
+1. Do not modify `CMAKE_FIND_LIBRARY_PREFIXES` and `CMAKE_FIND_LIBRARY_SUFFIXES` on Windows
+    * [Pull request #189](https://github.com/ignitionrobotics/ign-cmake/pull/189)
+
+1. Project option: `REPLACE_IGNITION_INCLUDE_PATH`
+    * [Pull request #190](https://github.com/ignitionrobotics/ign-cmake/pull/190)
+
+1. Project option: `NO_IGNITION_PREFIX`
+    * [Pull request #191](https://github.com/ignitionrobotics/ign-cmake/pull/191)
 
 ### Ignition CMake 2.9.0 (2021-09-02)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.10.0~pre1 release.

Comparison to 2.9.0: https://github.com/ignitionrobotics/ign-cmake/compare/ignition-cmake2_2.9.0...ign-cmake2

Needed by https://github.com/ignitionrobotics/sdformat/pull/747

## Checklist
- [ ] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
