### PR TITLE
Add HIDE_SYMBOLS_BY_DEFAULT option

### DIFF
--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -25,7 +25,6 @@
 # Configure the build of the ignition project
 # Pass the argument HIDE_SYMBOLS_BY_DEFAULT to configure symbol visibility so
 # that symbols are hidden unless explicitly marked as visible.
-# build_errors
 # Pass the argument QUIT_IF_BUILD_ERRORS to have this macro quit cmake when the
 # build_errors
 macro(ign_configure_build)

--- a/cmake/IgnConfigureBuild.cmake
+++ b/cmake/IgnConfigureBuild.cmake
@@ -23,13 +23,16 @@
 
 #################################################
 # Configure the build of the ignition project
+# Pass the argument HIDE_SYMBOLS_BY_DEFAULT to configure symbol visibility so
+# that symbols are hidden unless explicitly marked as visible.
+# build_errors
 # Pass the argument QUIT_IF_BUILD_ERRORS to have this macro quit cmake when the
 # build_errors
 macro(ign_configure_build)
 
   #============================================================================
   # Parse the arguments that are passed in
-  set(options QUIT_IF_BUILD_ERRORS)
+  set(options HIDE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
   set(oneValueArgs)
   set(multiValueArgs COMPONENTS)
   cmake_parse_arguments(ign_configure_build "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})

--- a/cmake/IgnSetCompilerFlags.cmake
+++ b/cmake/IgnSetCompilerFlags.cmake
@@ -115,11 +115,18 @@ endmacro()
 # Set up compilation flags for GCC or Clang
 macro(ign_setup_gcc_or_clang)
 
+  option(USE_DEFAULT_VISIBILITY_HIDDEN "Hide symbols by default if they are not explicitly specified as visible" FALSE)
+  if(USE_DEFAULT_VISIBILITY_HIDDEN)
+    set(VISIBILITY_FLAG "-fvisibility=hidden")
+  else()
+    set(VISIBILITY_FLAG "-fvisibility")
+  endif()
+
   ign_filter_valid_compiler_options(
     CUSTOM_ALL_FLAGS
         -Wall -Wextra -Wno-long-long -Wno-unused-value -Wfloat-equal
         -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic
-        -fvisibility)
+        ${VISIBILITY_FLAG})
 
   # -ggdb3: Produce comprehensive debug information that can be utilized by gdb
   set(CUSTOM_DEBUG_FLAGS "-ggdb3")

--- a/cmake/IgnSetCompilerFlags.cmake
+++ b/cmake/IgnSetCompilerFlags.cmake
@@ -115,18 +115,20 @@ endmacro()
 # Set up compilation flags for GCC or Clang
 macro(ign_setup_gcc_or_clang)
 
-  option(USE_DEFAULT_VISIBILITY_HIDDEN "Hide symbols by default if they are not explicitly specified as visible" FALSE)
-  if(USE_DEFAULT_VISIBILITY_HIDDEN)
-    set(VISIBILITY_FLAG "-fvisibility=hidden")
+  if(ign_configure_build_HIDE_SYMBOLS_BY_DEFAULT)
+    set(CMAKE_C_VISIBILITY_PRESET "hidden")
+    set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
   else()
-    set(VISIBILITY_FLAG "-fvisibility")
+    set(CMAKE_C_VISIBILITY_PRESET "default")
+    set(CMAKE_CXX_VISIBILITY_PRESET "default")
   endif()
+
 
   ign_filter_valid_compiler_options(
     CUSTOM_ALL_FLAGS
         -Wall -Wextra -Wno-long-long -Wno-unused-value -Wfloat-equal
         -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic
-        ${VISIBILITY_FLAG})
+        )
 
   # -ggdb3: Produce comprehensive debug information that can be utilized by gdb
   set(CUSTOM_DEBUG_FLAGS "-ggdb3")


### PR DESCRIPTION
# 🎉 New feature

Closes #166

## Summary

Add cmake option to `IgnSetCompilerFlags` that will hide symbols by default if they are not explicitly specified as visible. This option is disabled by default to match the current behavior of ign-cmake.

## Test it

The option is used in https://github.com/ignitionrobotics/sdformat/pull/780/commits/3a37dc8ad62dcefa3f36a696d97e140d6eaedabe from https://github.com/ignitionrobotics/sdformat/pull/780. To confirm that it works, remove some of the `target_sources` cmake calls added in https://github.com/ignitionrobotics/sdformat/pull/780/commits/3a37dc8ad62dcefa3f36a696d97e140d6eaedabe and observe the linking errors.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
