### PR TITLE
Doxygen allow all .cc .hh and CMakeLists.txt files

### DIFF
--- a/doc/doxygen/api.in
+++ b/doc/doxygen/api.in
@@ -859,7 +859,7 @@ EXCLUDE_SYMBOLS        = detail
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@/examples
+EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -867,7 +867,8 @@ EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@/examples
 # files are included.
 
 EXAMPLE_PATTERNS       = *.cc \
-                         *.hh
+                         *.hh \
+                         CMakeLists.txt
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands


### PR DESCRIPTION
# 🦟 Bug fix

Followup of https://github.com/ignitionrobotics/ign-physics/pull/312
See https://github.com/ignitionrobotics/ign-physics/pull/312#discussion_r763181447 and https://github.com/ignitionrobotics/ign-physics/pull/312#discussion_r763197818

## Summary

Some of our tutorials reference snippets in files not in the `examples` directory, which currently is the only place we allow snippets from. This PR extends the wildcard to allow all .hh, .cc, and adds CMakeLists.txt files.

Will open PR in `ign-physics` to demonstrate this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.