### PR TITLE
Add LEGACY_PROJECT_PREFIX option

### DIFF
--- a/cmake/IgnPackaging.cmake
+++ b/cmake/IgnPackaging.cmake
@@ -216,11 +216,16 @@ endfunction()
 
 
 #################################################
-# _ign_create_cmake_package([COMPONENT <component>])
+# _ign_create_cmake_package([COMPONENT <component>]
+#                           [LEGACY_PROJECT_PREFIX <prefix>])
 #
 # Provide the name of the target that will be installed and exported. If the
 # target is a component, pass in the COMPONENT argument followed by the
 # component's name.
+#
+# For packages like sdformat that use inconsistent case in the legacy cmake
+# variable names (like SDFormat_LIBRARIES), the LEGACY_PROJECT_PREFIX argument
+# can be used to specify the prefix of these variables.
 #
 # NOTE: This will be called automatically by ign_create_core_library(~) and
 #       ign_add_component(~), so users of ignition-cmake should not call this
@@ -239,7 +244,7 @@ function(_ign_create_cmake_package)
   #------------------------------------
   # Define the expected arguments
   set(options ALL)
-  set(oneValueArgs COMPONENT) # Unused
+  set(oneValueArgs COMPONENT LEGACY_PROJECT_PREFIX)
   set(multiValueArgs) # Unused
 
   #------------------------------------
@@ -276,7 +281,15 @@ function(_ign_create_cmake_package)
 
   endif()
 
+  if(_ign_create_cmake_package_LEGACY_PROJECT_PREFIX)
 
+    set(LEGACY_PROJECT_PREFIX ${_ign_create_cmake_package_LEGACY_PROJECT_PREFIX})
+
+  else()
+
+    set(LEGACY_PROJECT_PREFIX ${PROJECT_NAME_NO_VERSION_UPPER})
+
+  endif()
 
   # This gets used by the ignition-*.config.cmake.in files
   set(target_output_filename ${target_name}-targets.cmake)

--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -872,6 +872,7 @@ endmacro()
 #                         [CXX_STANDARD <11|14|17>]
 #                         [PRIVATE_CXX_STANDARD <11|14|17>]
 #                         [INTERFACE_CXX_STANDARD <11|14|17>]
+#                         [LEGACY_PROJECT_PREFIX <prefix>]
 #                         [GET_TARGET_NAME <output_var>])
 #
 # This function will produce the "core" library for your project. There is no
@@ -885,6 +886,10 @@ endmacro()
 #                    set to the library target name that gets produced by this
 #                    function. The target name will always be
 #                    ${PROJECT_LIBRARY_TARGET_NAME}.
+#
+# [LEGACY_PROJECT_PREFIX]: Optional. The variable that follows this argument will be
+#                          used as a prefix for the legacy cmake config variables
+#                          <prefix>_LIBRARIES and <prefix>_INCLUDE_DIRS.
 #
 # If you need a specific C++ standard, you must also specify it in this
 # function in order to ensure that your library's target properties get set
@@ -911,7 +916,7 @@ function(ign_create_core_library)
   #------------------------------------
   # Define the expected arguments
   set(options INTERFACE)
-  set(oneValueArgs INCLUDE_SUBDIR CXX_STANDARD PRIVATE_CXX_STANDARD INTERFACE_CXX_STANDARD GET_TARGET_NAME)
+  set(oneValueArgs INCLUDE_SUBDIR LEGACY_PROJECT_PREFIX CXX_STANDARD PRIVATE_CXX_STANDARD INTERFACE_CXX_STANDARD GET_TARGET_NAME)
   set(multiValueArgs SOURCES)
 
   #------------------------------------
@@ -992,7 +997,7 @@ function(ign_create_core_library)
   endif()
 
   # Export and install the core library's cmake target and package information
-  _ign_create_cmake_package()
+  _ign_create_cmake_package(LEGACY_PROJECT_PREFIX ${ign_create_core_library_LEGACY_PROJECT_PREFIX})
 
   # Generate and install the core library's pkgconfig information
   _ign_create_pkgconfig()

--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -872,8 +872,8 @@ endmacro()
 #                         [CXX_STANDARD <11|14|17>]
 #                         [PRIVATE_CXX_STANDARD <11|14|17>]
 #                         [INTERFACE_CXX_STANDARD <11|14|17>]
-#                         [LEGACY_PROJECT_PREFIX <prefix>]
-#                         [GET_TARGET_NAME <output_var>])
+#                         [GET_TARGET_NAME <output_var>]
+#                         [LEGACY_PROJECT_PREFIX <prefix>])
 #
 # This function will produce the "core" library for your project. There is no
 # need to specify a name for the library, because that will be determined by

--- a/cmake/ignition-config.cmake.in
+++ b/cmake/ignition-config.cmake.in
@@ -140,8 +140,8 @@ set(@PKG_NAME@_LIBRARIES @ign_namespace@requested)
 set_and_check(@PKG_NAME@_INCLUDE_DIRS "@PACKAGE_IGN_INCLUDE_INSTALL_DIR_FULL@")
 
 # Backwards compatibility variables
-set(@PROJECT_NAME_NO_VERSION_UPPER@_LIBRARIES ${@PKG_NAME@_LIBRARIES})
-set(@PROJECT_NAME_NO_VERSION_UPPER@_INCLUDE_DIRS ${@PKG_NAME@_INCLUDE_DIRS})
+set(@LEGACY_PROJECT_PREFIX@_LIBRARIES ${@PKG_NAME@_LIBRARIES})
+set(@LEGACY_PROJECT_PREFIX@_INCLUDE_DIRS ${@PKG_NAME@_INCLUDE_DIRS})
 
 # This macro is used by ignition-cmake to automatically configure the pkgconfig
 # files for ignition projects.


### PR DESCRIPTION
# 🎉 New feature

Needed by https://github.com/ignitionrobotics/sdformat/pull/780

## Summary

The cmake config template file currently creates legacy cmake variables with capital letters like `IGNITION-MATH_LIBRARIES` and `IGNITION-MATH_INCLUDE_DIRS`. In order to support a project with inconsistent case in the legacy cmake variables, like `SDFormat_LIBRARIES`, the prefix for these variables is made configurable as `LEGACY_PROJECT_PREFIX` in the `ign_create_core_library` function.

## Test it
Compile against https://github.com/ignitionrobotics/sdformat/pull/780/commits/e987976dfa28ef532dd6a2860232c5ce5cb2e678

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
