### PR TITLE
Specify sanitizers using IGN_SANITIZERS cmake variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Replace `/path/to/install/dir` to whatever directory you want to install this pa
 
 # Usage
 
-This library is used internally by the ignition projects. See other ignition projects for examples of how this gets used.
+Documentation can be accessed at https://ignitionrobotics.org/libs/cmake
+[Examples](examples/) are available in this repository.
+[Tutorials](tutorials/) are also available in this repository.
 
 # Folder Structure
 

--- a/cmake/IgnCMake.cmake
+++ b/cmake/IgnCMake.cmake
@@ -30,6 +30,7 @@ include(IgnSetCompilerFlags)
 include(IgnConfigureBuild)
 include(IgnImportTarget)
 include(IgnPkgConfig)
+include(IgnSanitizers)
 
 #============================================================================
 # Native cmake modules

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -17,7 +17,7 @@
 
 include(CheckCXXSourceCompiles)
 
-set(USE_SANITIZER ""
+set(IGN_SANITIZER ""
     CACHE STRING
     "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -54,11 +54,6 @@ if(IGN_SANITIZER)
   unset(SANITIZER_SELECTED_FLAGS)
 
   if(UNIX)
-
-    if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-      append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    endif()
-
     if(IGN_SANITIZER MATCHES "([Aa]ddress)")
       # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
       message(STATUS "Testing with Address sanitizer")

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -1,0 +1,222 @@
+#
+# Copyright (C) 2018-2022 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Original code https://raw.githubusercontent.com/StableCoder/cmake-scripts/main/sanitizers.cmake
+
+include(CheckCXXSourceCompiles)
+
+option(IGN_SANITIZER
+  "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
+)
+
+function(append value)
+  foreach(variable ${ARGN})
+    set(${variable}
+        "${${variable}} ${value}"
+        PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
+function(append_quoteless value)
+  foreach(variable ${ARGN})
+    set(${variable}
+        ${${variable}} ${value}
+        PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
+function(test_san_flags return_var flags)
+  set(QUIET_BACKUP ${CMAKE_REQUIRED_QUIET})
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  unset(${return_var} CACHE)
+  set(FLAGS_BACKUP ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${flags}")
+  check_cxx_source_compiles("int main() { return 0; }" ${return_var})
+  set(CMAKE_REQUIRED_FLAGS "${FLAGS_BACKUP}")
+  set(CMAKE_REQUIRED_QUIET "${QUIET_BACKUP}")
+endfunction()
+
+if(IGN_SANITIZER)
+  append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+  unset(SANITIZER_SELECTED_FLAGS)
+
+  if(UNIX)
+
+    if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+      append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Aa]ddress)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
+      message(STATUS "Testing with Address sanitizer")
+      set(SANITIZER_ADDR_FLAG "-fsanitize=address")
+      test_san_flags(SANITIZER_ADDR_AVAILABLE ${SANITIZER_ADDR_FLAG})
+      if(SANITIZER_ADDR_AVAILABLE)
+        message(STATUS "  Building with Address sanitizer")
+        append("${SANITIZER_ADDR_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_ASAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR
+            "Address sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
+      set(SANITIZER_MEM_FLAG "-fsanitize=memory")
+      if(IGN_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+        message(STATUS "Testing with MemoryWithOrigins sanitizer")
+        append("-fsanitize-memory-track-origins" SANITIZER_MEM_FLAG)
+      else()
+        message(STATUS "Testing with Memory sanitizer")
+      endif()
+      test_san_flags(SANITIZER_MEM_AVAILABLE ${SANITIZER_MEM_FLAG})
+      if(SANITIZER_MEM_AVAILABLE)
+        if(IGN_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+          message(STATUS "  Building with MemoryWithOrigins sanitizer")
+        else()
+          message(STATUS "  Building with Memory sanitizer")
+        endif()
+        append("${SANITIZER_MEM_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_MSAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR
+            "Memory [With Origins] sanitizer not available for ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Uu]ndefined)")
+      message(STATUS "Testing with Undefined Behaviour sanitizer")
+      set(SANITIZER_UB_FLAG "-fsanitize=undefined")
+      if(EXISTS "${BLACKLIST_FILE}")
+        append("-fsanitize-blacklist=${BLACKLIST_FILE}" SANITIZER_UB_FLAG)
+      endif()
+      test_san_flags(SANITIZER_UB_AVAILABLE ${SANITIZER_UB_FLAG})
+      if(SANITIZER_UB_AVAILABLE)
+        message(STATUS "  Building with Undefined Behaviour sanitizer")
+        append("${SANITIZER_UB_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_UBSAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR
+            "Undefined Behaviour sanitizer not available for ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Tt]hread)")
+      message(STATUS "Testing with Thread sanitizer")
+      set(SANITIZER_THREAD_FLAG "-fsanitize=thread")
+      test_san_flags(SANITIZER_THREAD_AVAILABLE ${SANITIZER_THREAD_FLAG})
+      if(SANITIZER_THREAD_AVAILABLE)
+        message(STATUS "  Building with Thread sanitizer")
+        append("${SANITIZER_THREAD_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_TSAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Ll]eak)")
+      message(STATUS "Testing with Leak sanitizer")
+      set(SANITIZER_LEAK_FLAG "-fsanitize=leak")
+      test_san_flags(SANITIZER_LEAK_AVAILABLE ${SANITIZER_LEAK_FLAG})
+      if(SANITIZER_LEAK_AVAILABLE)
+        message(STATUS "  Building with Leak sanitizer")
+        append("${SANITIZER_LEAK_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_LSAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endif()
+
+    if(IGN_SANITIZER MATCHES "([Cc][Ff][Ii])")
+      message(STATUS "Testing with Control Flow Integrity(CFI) sanitizer")
+      set(SANITIZER_CFI_FLAG "-fsanitize=cfi")
+      test_san_flags(SANITIZER_CFI_AVAILABLE ${SANITIZER_CFI_FLAG})
+      if(SANITIZER_CFI_AVAILABLE)
+        message(STATUS "  Building with Control Flow Integrity(CFI) sanitizer")
+        append("${SANITIZER_LEAK_FLAG}" SANITIZER_SELECTED_FLAGS)
+
+        if(AFL)
+          append_quoteless(AFL_USE_CFISAN=1 CMAKE_C_COMPILER_LAUNCHER
+                           CMAKE_CXX_COMPILER_LAUNCHER)
+        endif()
+      else()
+        message(
+          FATAL_ERROR
+            "Control Flow Integrity(CFI) sanitizer not available for ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endif()
+
+    message(STATUS "Sanitizer flags: ${SANITIZER_SELECTED_FLAGS}")
+    test_san_flags(SANITIZER_SELECTED_COMPATIBLE ${SANITIZER_SELECTED_FLAGS})
+    if(SANITIZER_SELECTED_COMPATIBLE)
+      message(STATUS " Building with ${SANITIZER_SELECTED_FLAGS}")
+      append("${SANITIZER_SELECTED_FLAGS}" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(
+        FATAL_ERROR
+          " Sanitizer flags ${SANITIZER_SELECTED_FLAGS} are not compatible.")
+    endif()
+  elseif(MSVC)
+    if(IGN_SANITIZER MATCHES "([Aa]ddress)")
+      message(STATUS "Building with Address sanitizer")
+      append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+      if(AFL)
+        append_quoteless(AFL_USE_ASAN=1 CMAKE_C_COMPILER_LAUNCHER
+                         CMAKE_CXX_COMPILER_LAUNCHER)
+      endif()
+    else()
+      message(
+        FATAL_ERROR
+          "This sanitizer not yet supported in the MSVC environment: ${IGN_SANITIZER}"
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "IGN_SANITIZER is not supported on this platform.")
+  endif()
+
+endif()

--- a/cmake/IgnSanitizers.cmake
+++ b/cmake/IgnSanitizers.cmake
@@ -17,8 +17,9 @@
 
 include(CheckCXXSourceCompiles)
 
-option(IGN_SANITIZER
-  "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
+set(USE_SANITIZER ""
+    CACHE STRING
+    "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"
 )
 
 function(append value)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -204,28 +204,30 @@ if (UNIX)
     ENVIRONMENT "${_env_vars}")
 endif()
 
-# Test for the sanitizers example
-set(sanitizer_compiler_log ${CMAKE_BINARY_DIR}/examples/Sanitizers-prefix/src/Sanitizers-stamp/Sanitizers-build-out.log)
-ExternalProject_Add(
-  Sanitizers
+if(UNIX)
+  # Test for the sanitizers example
+  set(sanitizer_compiler_log ${CMAKE_BINARY_DIR}/examples/Sanitizers-prefix/src/Sanitizers-stamp/Sanitizers-build-out.log)
+  ExternalProject_Add(
+    Sanitizers
 
-  DEPENDS FAKE_INSTALL
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sanitizers"
-  LOG_BUILD ON
-  LOG_CONFIGURE ON
-  # BUILD_ALWAYS needed since cmake doesn't notice when
-  # example files change.
-  # See alternate approach in a2113e0997c9 if this becomes too slow
-  BUILD_ALWAYS 1
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . --clean-first
-  CMAKE_ARGS
-    "-DCMAKE_PREFIX_PATH=${FAKE_INSTALL_PREFIX};${example_INSTALL_DIR}"
-    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/install/Sanitizers"
-    "-DIGN_SANITIZER=Address"
-    "-DCMAKE_CXX_FLAGS=-Wno-unused-parameter"
-    "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-  TEST_COMMAND
-    # Multiplatform python equivalent to grep "fsanitize=address" "${sanitizer_compiler_log}"
-    python3 -c "exec(\"import sys\\nwith open('${sanitizer_compiler_log}') as f:sys.exit(0) if 'fsanitize=address' in f.read() else sys.exit(1)\")"
-)
+    DEPENDS FAKE_INSTALL
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sanitizers"
+    LOG_BUILD ON
+    LOG_CONFIGURE ON
+    # BUILD_ALWAYS needed since cmake doesn't notice when
+    # example files change.
+    # See alternate approach in a2113e0997c9 if this becomes too slow
+    BUILD_ALWAYS 1
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . --clean-first
+    CMAKE_ARGS
+      "-DCMAKE_PREFIX_PATH=${FAKE_INSTALL_PREFIX};${example_INSTALL_DIR}"
+      "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+      "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/install/Sanitizers"
+      "-DIGN_SANITIZER=Address"
+      "-DCMAKE_CXX_FLAGS=-Wno-unused-parameter"
+      "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+    TEST_COMMAND
+      # Multiplatform python equivalent to grep "fsanitize=address" "${sanitizer_compiler_log}"
+      python3 -c "exec(\"import sys\\nwith open('${sanitizer_compiler_log}') as f:sys.exit(0) if 'fsanitize=address' in f.read() else sys.exit(1)\")"
+  )
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -203,3 +203,29 @@ if (UNIX)
   set_tests_properties(${TEST_NAME} PROPERTIES
     ENVIRONMENT "${_env_vars}")
 endif()
+
+# Test for the sanitizers example
+set(sanitizer_compiler_log ${CMAKE_BINARY_DIR}/examples/Sanitizers-prefix/src/Sanitizers-stamp/Sanitizers-build-out.log)
+ExternalProject_Add(
+  Sanitizers
+
+  DEPENDS FAKE_INSTALL
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sanitizers"
+  LOG_BUILD ON
+  LOG_CONFIGURE ON
+  # BUILD_ALWAYS needed since cmake doesn't notice when
+  # example files change.
+  # See alternate approach in a2113e0997c9 if this becomes too slow
+  BUILD_ALWAYS 1
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . --clean-first
+  CMAKE_ARGS
+    "-DCMAKE_PREFIX_PATH=${FAKE_INSTALL_PREFIX};${example_INSTALL_DIR}"
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/install/Sanitizers"
+    "-DIGN_SANITIZER=Address"
+    "-DCMAKE_CXX_FLAGS=-Wno-unused-parameter"
+    "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+  TEST_COMMAND
+    # Multiplatform python equivalent to grep "fsanitize=address" "${sanitizer_compiler_log}"
+    python3 -c "exec(\"import sys\\nwith open('${sanitizer_compiler_log}') as f:sys.exit(0) if 'fsanitize=address' in f.read() else sys.exit(1)\")"
+)

--- a/examples/sanitizers/CMakeLists.txt
+++ b/examples/sanitizers/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+project(ignition-sanitizers VERSION 0.1.0)
+find_package(ignition-cmake2 REQUIRED)
+ign_configure_project()
+ign_configure_build(QUIT_IF_BUILD_ERRORS)

--- a/examples/sanitizers/src/CMakeLists.txt
+++ b/examples/sanitizers/src/CMakeLists.txt
@@ -1,0 +1,3 @@
+ign_get_libsources_and_unittests(sources gtest_sources)
+ign_add_executable(asanfail ${sources})
+add_test(asan asanfail)

--- a/examples/sanitizers/src/asan_fail.cc
+++ b/examples/sanitizers/src/asan_fail.cc
@@ -1,0 +1,21 @@
+/*
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+
+ Original code https://raw.githubusercontent.com/StableCoder/cmake-scripts/main/example/src/asan_fail.cpp
+*/
+
+int main(int argc, char * argv[]) {
+    int *array = new int[100];
+    delete[] array;
+    return array[argc]; // BOOM
+}

--- a/examples/sanitizers/src/asan_fail.cc
+++ b/examples/sanitizers/src/asan_fail.cc
@@ -1,21 +1,23 @@
 /*
- Licensed under the Apache License, Version 2.0 (the "License"); you may not
- use this file except in compliance with the License. You may obtain a copy of
- the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- License for the specific language governing permissions and limitations under
- the License.
-
- Original code https://raw.githubusercontent.com/StableCoder/cmake-scripts/main/example/src/asan_fail.cpp
+ * Copyright (C) 2018-2022 by George Cave - gcave@stablecoder.ca
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Original code https://raw.githubusercontent.com/StableCoder/cmake-scripts/main/example/src/asan_fail.cpp
 */
 
 int main(int argc, char * argv[]) {
     int *array = new int[100];
     delete[] array;
-    return array[argc]; // BOOM
+    return array[argc];  // BOOM
 }

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -9,6 +9,7 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 
 1. \subpage install "Installation"
 1. \subpage developingwithcmake "Developing with Ignition CMake"
+1. \subpage sanitizersbuilds "Sanitizers Builds"
 
 ## License
 

--- a/tutorials/developing_with_ign-cmake.md
+++ b/tutorials/developing_with_ign-cmake.md
@@ -98,8 +98,8 @@ To change the build system type, set the CMake flag:
 
 ### Build sanitizers
 
-`USE_SANITIZER` CMake parameter can be used with different compilers to support the detection of different problems in the code.
-[Check the documentation for `USE_SANITIZER` flag](ign_cmake_sanitizers.md)
+`IGN_SANITIZER` CMake parameter can be used with different compilers to support the detection of different problems in the code.
+[Check the documentation for `IGN_SANITIZER` flag](ign_cmake_sanitizers.md)
 
 ### Using CCache
 

--- a/tutorials/developing_with_ign-cmake.md
+++ b/tutorials/developing_with_ign-cmake.md
@@ -96,26 +96,10 @@ To change the build system type, set the CMake flag:
 -GNinja
 ```
 
-### Address sanitizer (ASan)
+### Build sanitizers
 
-The `gcc` and `clang` compilers have a set of flags to generate instrumented builds for detecting memory leaks.
-
-By default, address sanitizer is *not used*.
-
-To enable address sanitizer, set all of the following flags:
-
-```
--DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=leak -g"
--DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=leak -g"
--DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address -fsanitize=leak"
--DCMAKE_MODULE_LINKER_FLAGS="-fsanitize=address -fsanitize=leak"
-```
-
-This will report if memory is leaked during execution of binaries or tests.
-
-More information about address santizier can be found in the [ASan documentation](https://github.com/google/sanitizers/wiki/AddressSanitizer).
-
-Note: Address sanitizer may have an impact on the performance of execution.
+`USE_SANITIZER` CMake parameter can be used with different compilers to support the detection of different problems in the code.
+[Check the documentation for `USE_SANITIZER` flag](ign_cmake_sanitizers.md)
 
 ### Using CCache
 

--- a/tutorials/ign_cmake_sanitizers.md
+++ b/tutorials/ign_cmake_sanitizers.md
@@ -1,0 +1,41 @@
+# Sanitizer Builds
+
+## Original source and Copyright
+
+The original work for these instructions is the project https://github.com/StableCoder/cmake-scripts/ licensed under the Apache-2 with the following copyright:
+
+> Copyright (C) 2018-2022 by George Cave - gcave@stablecoder.ca
+
+## Description
+
+Sanitizers are tools that perform checks during a program’s runtime and returns issues, and as such, along with unit testing, code coverage and static analysis, is another tool to add to the programmers toolbox. And of course, like the previous tools, are tragically simple to add into any project using CMake, allowing any project and developer to quickly and easily use.
+
+A quick rundown of the tools available, and what they do:
+- [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) detects memory leaks, or issues where memory is allocated and never deallocated, causing programs to slowly consume more and more memory, eventually leading to a crash.
+- [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) is a fast memory error detector. It is useful for detecting most issues dealing with memory, such as:
+    - Out of bounds accesses to heap, stack, global
+    - Use after free
+    - Use after return
+    - Use after scope
+    - Double-free, invalid free
+    - Memory leaks (using LeakSanitizer)
+- [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) detects data races for multi-threaded code.
+- [UndefinedBehaviourSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) detects the use of various features of C/C++ that are explicitly listed as resulting in undefined behaviour. Most notably:
+    - Using misaligned or null pointer.
+    - Signed integer overflow
+    - Conversion to, from, or between floating-point types which would overflow the destination
+    - Division by zero
+    - Unreachable code
+- [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) detects uninitialized reads.
+- [Control Flow Integrity](https://clang.llvm.org/docs/ControlFlowIntegrity.html) is designed to detect certain forms of undefined behaviour that can potentially allow attackers to subvert the program's control flow.
+
+These are used by declaring the `IGN_USE_SANITIZER` CMake variable as string containing any of:
+- Address
+- Memory
+- MemoryWithOrigins
+- Undefined
+- Thread
+- Leak
+- CFI
+
+Multiple values are allowed, e.g. `-DIGN_USE_SANITIZER=Address,Leak` but some sanitizers cannot be combined together, e.g.`-DIGN_USE_SANITIZER=Address,Memory` will result in configuration error. The delimeter character is not required and `-DIGN_USE_SANITIZER=AddressLeak` would work as well.

--- a/tutorials/ign_cmake_sanitizers.md
+++ b/tutorials/ign_cmake_sanitizers.md
@@ -29,7 +29,7 @@ A quick rundown of the tools available, and what they do:
 - [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) detects uninitialized reads.
 - [Control Flow Integrity](https://clang.llvm.org/docs/ControlFlowIntegrity.html) is designed to detect certain forms of undefined behaviour that can potentially allow attackers to subvert the program's control flow.
 
-These are used by declaring the `IGN_USE_SANITIZER` CMake variable as string containing any of:
+These are used by declaring the `IGN_SANITIZER` CMake variable as string containing any of:
 - Address
 - Memory
 - MemoryWithOrigins
@@ -38,4 +38,4 @@ These are used by declaring the `IGN_USE_SANITIZER` CMake variable as string con
 - Leak
 - CFI
 
-Multiple values are allowed, e.g. `-DIGN_USE_SANITIZER=Address,Leak` but some sanitizers cannot be combined together, e.g.`-DIGN_USE_SANITIZER=Address,Memory` will result in configuration error. The delimeter character is not required and `-DIGN_USE_SANITIZER=AddressLeak` would work as well.
+Multiple values are allowed, e.g. `-DIGN_SANITIZER=Address,Leak` but some sanitizers cannot be combined together, e.g.`-DIGN_SANITIZER=Address,Memory` will result in configuration error. The delimeter character is not required and `-DIGN_SANITIZER=AddressLeak` would work as well.


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignition-tooling/release-tools/issues/404

## Summary
The PR integrates the sanitizers compilers flags into ignition-cmake consumers to facilitate how to run them. It adds a CMake option of `IGN_SANITIZERS` that can be populated with different kind of sanitizers.

The work mostly integrated the code from https://github.com/StableCoder/cmake-scripts#sanitizer-builds-sanitizerscmake.

I added a test to run against the FAKE_INSTALL installation that checks that the compiler flag is being added to the compiler when using the CMake parameter.

## Test it

It can be used directly without colcon by passing `-DIGN_SANITIZERS=Address` or using colcon together with for example ignition-transport11:

```bash
colcon build --merge-install --executor sequential --cmake-args -DIGN_SANITIZER=Address -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --event-handlers console_direct+
colcon test --merge-install
```

Some tests are failing due to problems with the sanitizer:
<details>

```bash
33: [ RUN      ] ignTest.ServiceRequest                                                                                                                                                                                           
33: /home/jrivero/code/ignition/ws_asan/src/ign-transport/src/cmd/ign_TEST.cc:390: Failure                                                                                                                                        
33: Expected equality of these values:                                                                                                                                                                                            
33:   output                                                                                                                                                                                                                      
33:     Which is: "Library error: libignition-tools-backward.so not found. Improved backtrace generation will be disabled\ndata: 10\n\n\n=================================================================\n==109340==ERROR: LeakSanitizer: detected memory leaks\n\nDirect leak of 64 byte(s
33:   "data: " + value + "\n\n"                                                                                                                                                                                                   
33:     Which is: "data: 10\n\n"                                                                                                                                                                                                  
33: With diff:                                                                                                                                                                                                                    
33: @@ -1,20 +1,2 @@                                                                                                                                                                                                              
33: -Library error: libignition-tools-backward.so not found. Improved backtrace generation will be disabled                                                                                                                       
33:  data: 10                                                                                                                                                                                                                     
33: -                                                                                                                                                                                                                             
33: -                                                                                                                                                                                                                             
33: -=================================================================                                                                                                                                                            
33: -==109340==ERROR: LeakSanitizer: detected memory leaks                                                                                                                                                                        
33: -                                                                                                                                                                                                                             
33: -Direct leak of 64 byte(s) in 2 object(s) allocated from:                                                                                                                                                                     
33: -    #0 0x7f632490a587 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:104                                                                                                                
33: -    #1 0x7f63243a7ee9 in ignition::msgs::Int32* google::protobuf::Arena::CreateMaybeMessage<ignition::msgs::Int32>(google::protobuf::Arena*) (/lib/x86_64-linux-gnu/libignition-msgs8.so.8+0x226ee9)                         
33: -    #2 0x5591192b87b6 in cmdServiceReq /home/jrivero/code/ignition/ws_asan/src/ign-transport/src/cmd/ign.cc:240                                                                                                              
33: -    #3 0x5591191db204 in std::function<void ()>::operator()() const /usr/include/c++/9/bits/std_function.h:688                                                                                                               
33: -    #4 0x5591191db204 in CLI::App::run_callback(bool) /usr/include/ignition/utils1/ignition/utils/cli/App.hpp:1918                                                                                                           
33: -    #5 0x5591191db204 in CLI::App::run_callback(bool) /usr/include/ignition/utils1/ignition/utils/cli/App.hpp:1898                                                                                                           
33: -    #6 0x55911929435e in CLI::App::parse(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&) /usr/include/ignition/utils1/ignition/utils/
33: -    #7 0x55911929435e in CLI::App::parse(int, char const* const*) /usr/include/ignition/utils1/ignition/utils/cli/App.hpp:1233                                                                                               
33: -    #8 0x5591191c6eeb in main /home/jrivero/code/ignition/ws_asan/src/ign-transport/src/cmd/service_main.cc:134                                                                                                              
33: -    #9 0x7f63237730b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)                                                                                                                                         
33: -                                                                                                                                                                                                                             
33: -SUMMARY: AddressSanitizer: 64 byte(s) leaked in 2 allocation(s).\n                                                                                                                                                           
33: +\n                                                                                                                                                                                                                           
33:·                                                                                                                                                                                                                              
33: [  FAILED  ] ignTest.ServiceRequest (494 ms)                                                                                     
```
</details>

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial: I might need some feedback from @chapulina about where is the best place to host the tutorial. In this same repository under `examples`? I place it under tutorials [c1bc190](https://github.com/ignitionrobotics/ign-cmake/pull/210/commits/c1bc19070f05ba63f8bbf4fb738678591401a46d)
- [x] Updated documentation (as needed) I also welcome feedback about where to place a copy of https://github.com/StableCoder/cmake-scripts#sanitizer-builds-sanitizerscmake that is great. [c1bc190](https://github.com/ignitionrobotics/ign-cmake/pull/210/commits/c1bc19070f05ba63f8bbf4fb738678591401a46d)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.