### PR TITLE
Replace deprecated PythonInterp with Python3

### DIFF
--- a/cmake/IgnCodeCheck.cmake
+++ b/cmake/IgnCodeCheck.cmake
@@ -44,9 +44,9 @@ function(ign_setup_target_for_codecheck)
     DEPENDS cppcheck
   )
 
-  if(PYTHONINTERP_FOUND)
+  if(Python3_Interpreter_FOUND)
     add_custom_target(cpplint
-      COMMAND ${PYTHON_EXECUTABLE} ${IGNITION_CMAKE_CODECHECK_DIR}/cpplint.py --extensions=cc,hh --quiet `${CPPCHECK_FIND}`
+      COMMAND ${Python3_EXECUTABLE} ${IGNITION_CMAKE_CODECHECK_DIR}/cpplint.py --extensions=cc,hh --quiet `${CPPCHECK_FIND}`
     )
 
     add_dependencies(codecheck cpplint)

--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copied from ament/ament_cmake: ament_cmake/ament_cmake_core/cmake/core/python.cmake
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
+  set(PYTHON_VERSION "" CACHE STRING
+    "Specify specific Python3 version to use ('major.minor' or 'versionMin...[<]versionMax')")
 
-set(PYTHON_VERSION "" CACHE STRING
-  "Specify specific Python version to use ('major.minor' or 'major')")
+  find_package(Python3 ${PYTHON_VERSION} QUIET)
+elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+  # no support for finding specific versions
+  find_package(Python3 QUIET)
+else()
+  # TODO: remove this block as soon as the CMake version can safely be bumped to => 3.12
+  set(PYTHON_VERSION "" CACHE STRING
+    "Specify specific Python version to use ('major.minor' or 'major')")
 
-# if not specified otherwise use Python 3
-if(NOT PYTHON_VERSION)
-  set(PYTHON_VERSION "3")
+  # if not specified otherwise use Python 3
+  if(NOT PYTHON_VERSION)
+    set(PYTHON_VERSION "3")
+  endif()
+
+  find_package(PythonInterp ${PYTHON_VERSION} QUIET)
+
+  if(PYTHONINTERP_FOUND)
+    set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
+    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+  endif()
 endif()
-
-find_package(PythonInterp ${PYTHON_VERSION} QUIET)

--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -13,24 +13,24 @@
 # limitations under the License.
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
-  set(PYTHON_VERSION "" CACHE STRING
+  set(IGN_PYTHON_VERSION "" CACHE STRING
     "Specify specific Python3 version to use ('major.minor' or 'versionMin...[<]versionMax')")
 
-  find_package(Python3 ${PYTHON_VERSION} QUIET)
+  find_package(Python3 ${IGN_PYTHON_VERSION} QUIET)
 elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
   # no support for finding specific versions
   find_package(Python3 QUIET)
 else()
   # TODO: remove this block as soon as the CMake version can safely be bumped to => 3.12
-  set(PYTHON_VERSION "" CACHE STRING
+  set(IGN_PYTHON_VERSION "" CACHE STRING
     "Specify specific Python version to use ('major.minor' or 'major')")
 
   # if not specified otherwise use Python 3
-  if(NOT PYTHON_VERSION)
-    set(PYTHON_VERSION "3")
+  if(NOT IGN_PYTHON_VERSION)
+    set(IGN_PYTHON_VERSION "3")
   endif()
 
-  find_package(PythonInterp ${PYTHON_VERSION} QUIET)
+  find_package(PythonInterp ${IGN_PYTHON_VERSION} QUIET)
 
   if(PYTHONINTERP_FOUND)
     set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})

--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -1695,7 +1695,6 @@ macro(ign_build_tests)
 
     # Find the Python interpreter for running the
     # check_test_ran.py script
-
     include(IgnPython)
 
     # Build all the tests
@@ -1715,10 +1714,10 @@ macro(ign_build_tests)
 
       set_tests_properties(${target_name} PROPERTIES TIMEOUT 240)
 
-      if(PYTHONINTERP_FOUND)
+      if(Python3_Interpreter_FOUND)
         # Check that the test produced a result and create a failure if it didn't.
         # Guards against crashed and timed out tests.
-        add_test(check_${target_name} ${PYTHON_EXECUTABLE} ${IGNITION_CMAKE_TOOLS_DIR}/check_test_ran.py
+        add_test(check_${target_name} ${Python3_EXECUTABLE} ${IGNITION_CMAKE_TOOLS_DIR}/check_test_ran.py
           ${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
       endif()
     endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #212 

## Summary
`PythonInterp` is deprecated for CMake versions > 3.11 and all scripts use Python3 features anyway, so replace it with the recommended `find_package(Python3)` but also provide fallback solutions until the required CMake version can be bumped.
**Note**: Some small adjustments may be required in other packages to use the new variables. If the changes here are fine I will create the other PR's.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.