### PR TITLE
Fix UNIX check for missing components in OGRE2. Be more verbose with components

### DIFF
--- a/cmake/FindIgnOGRE2.cmake
+++ b/cmake/FindIgnOGRE2.cmake
@@ -57,7 +57,7 @@ if (${IgnOGRE2_FIND_VERSION_MAJOR})
   endif()
 endif()
 
-message(STATUS "-- Finding OGRE 2.${IgnOGRE2_FIND_VERSION_MINOR}")
+message(STATUS " Version: 2.${IgnOGRE2_FIND_VERSION_MINOR}")
 set(OGRE2_INSTALL_PATH "OGRE-2.${IgnOGRE2_FIND_VERSION_MINOR}")
 
 macro(append_library VAR LIB)
@@ -226,8 +226,8 @@ if (NOT WIN32)
         "Ogre${component}.${OGRE2_VERSION}"
         "Ogre${component}"
       HINTS ${OGRE2_LIBRARY_DIRS})
-    if (NOT "OGRE2-${component}" STREQUAL "OGRE2-${component}-NOTFOUND")
-
+    if (NOT "${OGRE2-${component}}" STREQUAL "OGRE2-${component}-NOTFOUND")
+      message(STATUS " component ${component}: found")
       # create a new target for each component
       set(component_TARGET_NAME "IgnOGRE2-${component}::IgnOGRE2-${component}")
       set(component_INCLUDE_DIRS ${OGRE2_INCLUDE_DIRS})
@@ -256,6 +256,7 @@ if (NOT WIN32)
       list(APPEND OGRE2_LIBRARIES ${component_TARGET_NAME})
 
     elseif(IgnOGRE2_FIND_REQUIRED_${component})
+      message(STATUS " component ${component}: not found!")
       set(OGRE2_FOUND false)
     endif()
   endforeach()


### PR DESCRIPTION
The check `if (NOT "OGRE2-${component}" STREQUAL "OGRE2-${component}-NOTFOUND")` is going to return always true since `OGRE2-${component}` is never going to be `OGRE2-${component}-NOTFOUND`. What we really want to check is the content of the whole variable which, if I'm not wrong, should be: `${OGRE2-${component}}`.

The pull request includes a bit of output for the user to know when the detection of OGRE2 is failing the status of each component. Otherwise is hard to know what's going on. Example:

Current example in 2.2 (bug included that say OGRE2 was found, using a "fake component")
```
-- Looking for IgnOGRE2 - found

-- OGRE2_FOUND: TRUE
-- OGRE2_LIBRARIES: /usr/lib/x86_64-linux-gnu/OGRE-2.2/libOgreMain.soIgnOGRE2-HlmsPbs::IgnOGRE2-HlmsPbsIgnOGRE2-HlmsUnlit::IgnOGRE2-HlmsUnlitIgnOGRE2-Overlay::IgnOGRE2-OverlayIgnOGRE2-Fake::IgnOGRE2-Fake
```
With this PR:
```
-- Finding OGRE 2.2
--  Version: OGRE 2.2
--  component HlmsPbs: found
--  component HlmsUnlit: found
--  component Overlay: found
--  component Fake: not found!
-- Looking for IgnOGRE2 - not found

-- OGRE2_FOUND: false
-- OGRE2_LIBRARIES: /usr/lib/x86_64-linux-gnu/OGRE-2.2/libOgreMain.soIgnOGRE2-HlmsPbs::IgnOGRE2-HlmsPbsIgnOGRE2-HlmsUnlit::IgnOGRE2-HlmsUnlitIgnOGRE2-Overlay::IgnOGRE2-Overlay
```