### PR TITLE
IgnPython: restore PYTHON_EXECUTABLE for now

### DIFF
--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -39,6 +39,7 @@ else()
 endif()
 
 # Tick-tock PYTHON_EXECUTABLE until Python3_EXECUTABLE is released
+# TODO(jrivero) ign-cmake3: start the deprecation cycle of PYTHON_EXECUTABLE
 if(Python3_EXECUTABLE AND NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 endif()

--- a/cmake/IgnPython.cmake
+++ b/cmake/IgnPython.cmake
@@ -37,3 +37,8 @@ else()
     set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
   endif()
 endif()
+
+# Tick-tock PYTHON_EXECUTABLE until Python3_EXECUTABLE is released
+if(Python3_EXECUTABLE AND NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-math/issues/401

## Summary

The `PYTHON_EXECUTABLE` cmake variable was replaced by `Python3_EXECUTABLE` in #218 for new versions of cmake. This breaks packages currently using the previous variable name. This pull request restores `PYTHON_EXECUTABLE` to allow a tick-tock cycle for downstream packages to transition.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
