### PR TITLE
Allow to recreate targets created by IgnPkgConfig

### DIFF
--- a/cmake/IgnPkgConfig.cmake
+++ b/cmake/IgnPkgConfig.cmake
@@ -112,7 +112,7 @@ macro(ign_pkg_check_modules_quiet package signature)
     #       use the plain pkg_check_modules, which provides an option called
     #       IMPORTED_TARGET that will create the imported targets the way we do
     #       here.
-    if(${package}_FOUND AND NOT TARGET ${ign_pkg_check_modules_TARGET_NAME})
+    if(${package}_FOUND)
 
       # Because of some idiosyncrasies of pkg-config, pkg_check_modules does not
       # put /usr/include in the <prefix>_INCLUDE_DIRS variable. E.g. try running


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

There are problems when we call `ign_find_package` twice related to the recreation of a CMake target already created by `ign_pkg_check_modules_*` methods. The PR removes the check that avoid this option.

See https://github.com/ignitionrobotics/ign-rendering/pull/605 for an use case related to this limitation.

I've tested this with a fortress workspace on Focal and everything seems to built. It might be software affected out there but having the ability of calling a `ign_find_package` twice and recreate an CMake TARGET with updated information seems to me the way to go.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.