### PR TITLE
Option to install a header, but don't include it in master header

### DIFF
--- a/cmake/IgnUtils.cmake
+++ b/cmake/IgnUtils.cmake
@@ -602,6 +602,7 @@ endfunction()
 #   [EXCLUDE_FILES <excluded_headers>]
 #   [EXCLUDE_DIRS  <dirs>]
 #   [GENERATED_HEADERS <headers>]
+#   [INSTALL_BUT_DONT_INCLUDE <headers>]
 #   [COMPONENT] <component>)
 #
 # From the current directory, install all header files, including files from all
@@ -623,13 +624,17 @@ endfunction()
 # If the COMPONENT option is specified, this will skip over configuring a
 # config.hh file since it would be redundant with the core library.
 #
+# INSTALL_BUT_DONT_INCLUDE should be headers that are meant to be installed, but
+# not included in ${IGN_DESIGNATION}.hh. This is useful for deprecated headers,
+# for example.
+#
 function(ign_install_all_headers)
 
   #------------------------------------
   # Define the expected arguments
   set(options)
   set(oneValueArgs COMPONENT) # We are not using oneValueArgs yet
-  set(multiValueArgs EXCLUDE_FILES EXCLUDE_DIRS GENERATED_HEADERS)
+  set(multiValueArgs EXCLUDE_FILES EXCLUDE_DIRS GENERATED_HEADERS INSTALL_BUT_DONT_INCLUDE)
 
   #------------------------------------
   # Parse the arguments
@@ -695,7 +700,9 @@ function(ign_install_all_headers)
 
     # Add each header, prefixed by its directory, to the auto headers variable
     foreach(header ${headers})
-      set(ign_headers "${ign_headers}#include <${PROJECT_INCLUDE_DIR}/${header}>\n")
+      if (NOT ${header} IN_LIST ign_install_all_headers_INSTALL_BUT_DONT_INCLUDE)
+        set(ign_headers "${ign_headers}#include <${PROJECT_INCLUDE_DIR}/${header}>\n")
+      endif()
     endforeach()
 
     if("." STREQUAL ${dir})


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add an option to `ign_install_all_headers` so that a header is installed, but not included in the master header.

I need this feature because I introduced a bunch of warnings to everyone who includes `msgs.hh`  when I deprecated `SuppressWarning.hh` in

* https://github.com/ignitionrobotics/ign-msgs/pull/243

## Test it
<!--Explain how reviewers can test this new feature manually.-->

TODO

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
