### PR TITLE
Support project names starting with gz-

### DIFF
--- a/cmake/IgnConfigureProject.cmake
+++ b/cmake/IgnConfigureProject.cmake
@@ -56,11 +56,12 @@ macro(ign_configure_project)
   # Extract the designation
   #============================================================================
   set(IGN_DESIGNATION ${PROJECT_NAME})
-  # Remove the leading project prefix ("ignition-" by default)
-  set(PROJECT_PREFIX "ignition")
-  # Also support "gz-"
-  if(${IGN_DESIGNATION} MATCHES "^gz-")
-    set(PROJECT_PREFIX "gz")
+  # Remove the leading project prefix ("gz-" by default)
+  set(PROJECT_PREFIX "gz")
+  # Also support "ignition-"
+  # TODO: remove this `if` block once all package names start with gz
+  if(${IGN_DESIGNATION} MATCHES "^ignition-")
+    set(PROJECT_PREFIX "ignition")
   endif()
   string(REGEX REPLACE "${PROJECT_PREFIX}-" "" IGN_DESIGNATION ${IGN_DESIGNATION})
 

--- a/cmake/IgnConfigureProject.cmake
+++ b/cmake/IgnConfigureProject.cmake
@@ -56,8 +56,14 @@ macro(ign_configure_project)
   # Extract the designation
   #============================================================================
   set(IGN_DESIGNATION ${PROJECT_NAME})
-  # Remove the leading "ignition-"
-  string(REGEX REPLACE "ignition-" "" IGN_DESIGNATION ${IGN_DESIGNATION})
+  # Remove the leading project prefix ("ignition-" by default)
+  set(PROJECT_PREFIX "ignition")
+  # Also support "gz-"
+  if(${IGN_DESIGNATION} MATCHES "^gz-")
+    set(PROJECT_PREFIX "gz")
+  endif()
+  string(REGEX REPLACE "${PROJECT_PREFIX}-" "" IGN_DESIGNATION ${IGN_DESIGNATION})
+
   # Remove the trailing version number
   string(REGEX REPLACE "[0-9]+" "" IGN_DESIGNATION ${IGN_DESIGNATION})
 
@@ -68,7 +74,7 @@ macro(ign_configure_project)
   if(ign_configure_project_NO_IGNITION_PREFIX)
     set(PROJECT_NAME_NO_VERSION ${IGN_DESIGNATION})
   else()
-    set(PROJECT_NAME_NO_VERSION "ignition-${IGN_DESIGNATION}")
+    set(PROJECT_NAME_NO_VERSION "${PROJECT_PREFIX}-${IGN_DESIGNATION}")
   endif()
   string(TOLOWER ${PROJECT_NAME_NO_VERSION} PROJECT_NAME_NO_VERSION_LOWER)
   string(TOUPPER ${PROJECT_NAME_NO_VERSION} PROJECT_NAME_NO_VERSION_UPPER)


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignition-tooling/release-tools/issues/718 and s subset of #239 that supports project names starting with `gz-`

## Summary

There are quite a few changes in #239, but I'm not sure about all of them, so I split out the support for project names starting with `gz-` into this pull request (with a slightly different implementation).

## Test it

I've tested this a bit with https://github.com/ignitionrobotics/ign-utils/pull/57 and https://github.com/ignitionrobotics/ign-math/pull/420 (without the `gz-cmake3` project name), and it seems to be working.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
