### PR TITLE
Tentative fix for `FindOptiX.cmake`

### DIFF
--- a/cmake/FindOptiX.cmake
+++ b/cmake/FindOptiX.cmake
@@ -83,12 +83,12 @@ endif()
 # gz-cmake modification: added "gz_" prefix to macro name
 macro(gz_OPTIX_find_api_library name version)
   find_library(${name}_LIBRARY
-    NAMES ${name}.${version} ${name}
+    NAMES nv${name}.${version} nv${name}
     PATHS "${OptiX_INSTALL_DIR}/lib${bit_dest}"
     NO_DEFAULT_PATH
     )
   find_library(${name}_LIBRARY
-    NAMES ${name}.${version} ${name}
+    NAMES nv${name}.${version} nv${name}
     )
   if(WIN32)
     find_file(${name}_DLL
@@ -109,7 +109,7 @@ gz_OPTIX_find_api_library(optix_prime 1)
 # Include
 find_path(OptiX_INCLUDE
   NAMES optix.h
-  PATHS "${OptiX_INSTALL_DIR}/include"
+  PATHS "$ENV{OPTIX_INSTALL_DIR}/include"
   NO_DEFAULT_PATH
   )
 find_path(OptiX_INCLUDE


### PR DESCRIPTION
Lost some hours to fix `gz_rendering` build warnings about missing dependency `OptiX` only to find out in https://github.com/gazebosim/gz-rendering/issues/1010 that basically that renderer is ancient/broken... nevertheless, I think it would be good to leave here the bit and bolts that I discovered to be issue in my setup for `OptiX` discovery.

First of all, on Ubuntu 22.04 the library name is `libnvoptix.so.1` while this script currently searches for `liboptix.so` or `liboptix.1.so`, so the lookup would always fail IMHO.

Secondly, but it can be my fault, I tried setting:
- `--cmake-args OPTIX_INSTALL_DIR=path`
- `--cmake-args OptiX_INSTALL_DIR=path`
- export `OPTIX_INSTALL_DIR=path`

but the include files were never detected. I solved the hard way by directly checking the `$env` var in `find_path` call.