### PR TITLE
Fix broken keyserver url by replacing with wget

### DIFF
--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -20,7 +20,7 @@ On Ubuntu, it's possible to install Gazebo CMake as follows:
 Add OSRF packages:
   ```
   echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-  sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+  wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
   sudo apt update
   ```
 


### PR DESCRIPTION



<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #470 

## Summary

Replaced the keyserver url in install.md for gz-cmake with the wget , removing the broken link.

Current install instructions  provide the link for keyserver for downloading binaries through this link : 

```sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
```
which results in the output : 

```
W: GPG error: http://packages.osrfoundation.org/gazebo/ubuntu-stable noble InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 67170598AF249743
```

so updated it to 
```
wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
```
as suggested and used in  source install section.

Though it does generate warning that apt-get is depreciated. So should those warning be removed  using gpg signoff ?

<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


