### PR TITLE
Make Whole Program Optimization (WPO) optional on MSVC

### DIFF
--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -296,16 +296,26 @@ macro(_gz_setup_msvc)
     # performance and can be helpful for debugging.
     set(MSVC_DEBUG_FLAGS "${MSVC_MINIMAL_FLAGS} /Zi")
 
-    # GL: Enable Whole Program Optimization
-    set(MSVC_RELEASE_FLAGS "${MSVC_DEBUG_FLAGS} /GL")
+    option(GZ_MSVC_WPO "Enable Whole Program Optimization on MSVC" ON)
+    if(GZ_MSVC_WPO)
+      # GL: Enable Whole Program Optimization
+      set(MSVC_RELEASE_FLAGS "${MSVC_DEBUG_FLAGS} /GL")
 
-    # Use Release flags for RelWithDebInfo
-    set(MSVC_RELWITHDEBINFO_FLAGS "${MSVC_RELEASE_FLAGS}")
+      # Use Release flags for RelWithDebInfo
+      set(MSVC_RELWITHDEBINFO_FLAGS "${MSVC_RELEASE_FLAGS}")
 
-    # INCREMENTAL:NO fix LNK4075 warning
-    # LTCG: need when using /GL above
-    #  see https://docs.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization
-    set(MSVC_RELWITHDEBINFO_LINKER_FLAGS "/INCREMENTAL:NO /LTCG")
+      # LTCG: need when using /GL above
+      set(MSVC_RELEASE_LINKER_FLAGS "/LTCG")
+
+      # INCREMENTAL:NO fix LNK4075 warning
+      #  see https://docs.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization
+      set(MSVC_RELWITHDEBINFO_LINKER_FLAGS "/INCREMENTAL:NO /LTCG")
+    else()
+      set(MSVC_RELEASE_FLAGS "${MSVC_DEBUG_FLAGS}")
+      set(MSVC_RELWITHDEBINFO_FLAGS "${MSVC_RELEASE_FLAGS}")
+      set(MSVC_RELEASE_LINKER_FLAGS "")
+      set(MSVC_RELWITHDEBINFO_LINKER_FLAGS "/INCREMENTAL:NO")
+    endif()
 
     # cmake automatically provides /Zi /Ob0 /Od /RTC1
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${MSVC_DEBUG_FLAGS}")
@@ -314,11 +324,16 @@ macro(_gz_setup_msvc)
     # cmake automatically provides /O2 /Ob2 /DNDEBUG
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${MSVC_RELEASE_FLAGS}")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${MSVC_RELEASE_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} ${MSVC_RELEASE_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} ${MSVC_RELEASE_LINKER_FLAGS}")
+    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} ${MSVC_RELEASE_LINKER_FLAGS}")
 
     # cmake automatically provides /Zi /O2 /Ob1 /DNDEBUG
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${MSVC_RELWITHDEBINFO_FLAGS}")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${MSVC_RELWITHDEBINFO_FLAGS}")
     set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} ${MSVC_RELWITHDEBINFO_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} ${MSVC_RELWITHDEBINFO_LINKER_FLAGS}")
+    set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} ${MSVC_RELWITHDEBINFO_LINKER_FLAGS}")
 
     # cmake automatically provides /O1 /Ob1 /DNDEBUG
     set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} ${MSVC_MINIMAL_FLAGS}")

--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -289,7 +289,9 @@ macro(_gz_setup_msvc)
     # W2: Warning level 2: significant warnings.
     #     TODO: Recommend Wall in the future.
     #     Note: MSVC /Wall generates tons of warnings on gtest code.
-    set(MSVC_MINIMAL_FLAGS "/Gy /W2")
+    # bigobj: Increase the number of sections in an object file, which is often needed
+    #         for complex templated code or when using Whole Program Optimization (/GL).
+    set(MSVC_MINIMAL_FLAGS "/Gy /W2 /bigobj")
 
     # Zi: Produce complete debug information
     # Note: We provide Zi to ordinary release mode because it does not impact


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

This PR introduces an option to toggle Whole Program Optimization (WPO) on MSVC. On template heavy libraries such as gz-physics, WPO causes a large memory spike causing the system to do a lot of swapping thereby dramatically increasing the build time.  The current build time for gz-physics PRs on the `main` branch is 1h 17m (https://build.osrfoundation.org/job/gz_physics-pr-cnlwin/232/timings/). With WPO disabled, **it is reduced to 29m** 🎉  (https://build.osrfoundation.org/job/gz_physics-pr-cnlwin/234/timings).

This PR also fixes a few other bugs in the way flags are set on `CMAKE` variables:

* Fixed missing LTCG flags: Corrects an issue where the `/LTCG` linker flag was only being applied to `RelWithDebInfo` shared libraries. It is now correctly applied across all `Release` and `RelWithDebInfo` target types (executables, shared libraries, and static libraries) when WPO is enabled. This fixes the warnings in most of our windows builds, e.g.:
    ```  
    Environment.obj : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
    ```
* Added `/bigobj` to minimal MSVC flags: Included the `/bigobj` flag in `MSVC_MINIMAL_FLAGS`. This prevents `C1128: number of sections exceeded object file format limit` errors, which I believe now occurs because WPO is properly set on all targets (see https://build.osrfoundation.org/job/gz_sim-pr-cnlwin/668/).


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.0 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.