### PR TITLE
fix: Recognize AppleClang to enable recommended compiler flags on macOS

### DIFF
--- a/cmake/GzCodeCoverage.cmake
+++ b/cmake/GzCodeCoverage.cmake
@@ -51,7 +51,7 @@ IF(NOT CMAKE_COMPILER_IS_GNUCXX)
   # Clang version 3.0.0 and greater now supports gcov as well.
   MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
 
-  IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  IF(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"))
     MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
   ENDIF()
 ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX

--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -39,7 +39,7 @@ macro(_gz_set_compiler_flags)
   endif()
 
   # Check if we are compiling with Clang with GNU-like flags and cache it
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
       set(CLANG false)
     else()

--- a/cmake/GzSetCompilerFlags.cmake
+++ b/cmake/GzSetCompilerFlags.cmake
@@ -128,6 +128,15 @@ macro(_gz_setup_gcc_or_clang)
         -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic
         )
 
+  if(CLANG)
+    # Suppress warning about variadic macro arguments in gtest.
+    # This is needed for tests in gz-physics on macOS.
+    _gz_filter_valid_compiler_options(
+      CUSTOM_ALL_FLAGS
+          -Wno-variadic-macro-arguments-omitted
+          )
+  endif()
+
   # -ggdb3: Produce comprehensive debug information that can be utilized by gdb
   set(CUSTOM_DEBUG_FLAGS "-ggdb3")
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

While working on https://github.com/gazebosim/gz-physics/pull/946, I noticed that I wasn't getting any compiler warnings locally (on macOS), but they showed up on CI. It turns out the flags used for gcc on Linux and the ones used for clang on macOS are very different. Examples from `build.ninja`:

macOS
```
FLAGS = -stdlib=libc++ -O2 -g -DNDEBUG -std=c++17 -arch arm64 -fPIC
```
But on Linux
```
FLAGS = -O2 -g -DNDEBUG  -Wall -Wextra -Wno-long-long -Wno-unused-value -Wfloat-equal -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic  -std=c++17 -fPIC -fvisibility=hidden
```

Other than the macOS specific flags like `-stdlib` and `-arch`, the flags should have been equivalent where possible. The issue was that the compiler ID for Apple's Clang is 'AppleClang', which was not recognized by the scripts. This change ensures that AppleClang is treated similarly to standard Clang, applying the recommended warning flags.

With the new flags, gz-physics emitts additional warnings related to `TYPED_TEST_SUITE` for the code like the following tests in `test/common`:

```
template <class T>
class SimulationFeaturesShapeFeaturesTest :
  public SimulationFeaturesTest<T>{};
using SimulationFeaturesShapeFeaturesTestTypes =
  ::testing::Types<FeaturesShapeFeatures>;
TYPED_TEST_SUITE(SimulationFeaturesShapeFeaturesTest,
                 SimulationFeaturesShapeFeaturesTestTypes);
```
and the error message is
```
/Users/addisuzt/ws/rotary/src/gz-physics/test/common_test/simulation_features.cc:989:58: warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension [-Wvariadic-macro-arguments-omitted]
  989 |                  SimulationFeaturesShapeFeaturesTestTypes);
      |                                                          ^
/Users/addisuzt/ws/rotary/src/gz-physics/test/gtest_vendor/include/gtest/gtest-typed-test.h:191:9: note: macro 'TYPED_TEST_SUITE' defined here
  191 | #define TYPED_TEST_SUITE(CaseName, Types, ...)                          \
      |         ^
```

dd5ab89bf6a62618b9d597136c215383e0d54984 suppresses this warning to match gcc on Linux.

Edit: I've marked this as draft because this causes several warnings in other Gazebo libraries. Once those are all addressed, I'll mark this ready for review.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.0 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.