### PR TITLE
cpack should exclude .git/ from tarballs

### DIFF
--- a/cmake/GzPackaging.cmake
+++ b/cmake/GzPackaging.cmake
@@ -54,7 +54,9 @@ macro(_gz_setup_packages)
 
   list(APPEND CPACK_SOURCE_GENERATOR "TBZ2")
   list(APPEND CPACK_SOURCE_GENERATOR "ZIP")
-  list(APPEND CPACK_SOURCE_IGNORE_FILES "TODO;\.hg/;\.sw.$;/build/;\.hgtags;\.hgignore;appveyor\.yml;\.travis\.yml;codecov\.yml")
+  list(APPEND CPACK_SOURCE_IGNORE_FILES
+    /\\\\.git/
+    "TODO;\.hg/;\.sw.$;/build/;\.hgtags;\.hgignore;appveyor\.yml;\.travis\.yml;codecov\.yml")
 
   include(InstallRequiredSystemLibraries)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-cmake/issues/551.

## Summary

Add the `.git` folder to `CPACK_SOURCE_IGNORE_FILES` using the [recommended syntax](https://cmake.org/cmake/help/latest/module/CPack.html#variable:CPACK_SOURCE_IGNORE_FILES) with a regular expression that matches `.git/` exactly with proper escaping.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
