### PR TITLE
Prepare for 5.1.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(GzCMake)
 
 #--------------------------------------
 # Set up the project
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX)
 
 #--------------------------------------
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ## Gazebo CMake 5.x
 
+### Gazebo CMake 5.1.1 (2026-05-13)
+
+1. cpack should exclude .git/ from tarballs
+    * [Pull request #552](https://github.com/gazebosim/gz-cmake/pull/552)
+
+1. Use portable shebang (#!/usr/bin/env bash) for bash scripts
+    * [Pull request #542](https://github.com/gazebosim/gz-cmake/pull/542)
+    * [Pull request #543](https://github.com/gazebosim/gz-cmake/pull/543)
+
 ### Gazebo CMake 5.1.0 (2026-04-07)
 
 1. Guard GL3Plus include path in FindGzOGRE2


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.1.1 release, follow up to 5.1.1~pre1 prerelease in #557.

Comparison to 5.1.0: https://github.com/gazebosim/gz-cmake/compare/gz-cmake5_5.1.0...gz-cmake5

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
