### PR TITLE
Prepare for 3.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-cmake3 VERSION 3.5.6)
+project(gz-cmake3 VERSION 3.6.0)
 
 #--------------------------------------
 # Initialize the GZ_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,25 @@
 ## Gazebo CMake 3.x
 
+### Gazebo CMake 3.6.0 (2026-05-14)
+
+1. cpack should exclude .git/ from tarballs
+    * [Pull request #552](https://github.com/gazebosim/gz-cmake/pull/552)
+
+1. Use portable shebang (#!/usr/bin/env bash) for bash scripts
+    * [Pull request #542](https://github.com/gazebosim/gz-cmake/pull/542)
+    * [Pull request #545](https://github.com/gazebosim/gz-cmake/pull/545)
+
+1. Guard GL3Plus include path in FindGzOGRE2
+    * [Pull request #537](https://github.com/gazebosim/gz-cmake/pull/537)
+
+1. Make Whole Program Optimization (WPO) optional on MSVC
+    * [Pull request #532](https://github.com/gazebosim/gz-cmake/pull/532)
+    * [Pull request #533](https://github.com/gazebosim/gz-cmake/pull/533)
+
+1. Add a Doxygen filter for .h files
+    * [Pull request #523](https://github.com/gazebosim/gz-cmake/pull/523)
+    * [Pull request #526](https://github.com/gazebosim/gz-cmake/pull/526)
+
 ### Gazebo CMake 3.5.6 (2026-01-26)
 
 1. Fix dead material-design-lite links

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>gz-cmake3</name>
-  <version>3.5.6</version>
+  <version>3.6.0</version>
   <description>Gazebo CMake : CMake Modules for Gazebo Projects</description>
 
   <maintainer email="scpeters@openrobotics.org">Steve Peters</maintainer>


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.6.0 release.

Comparison to 3.5.6: https://github.com/gazebosim/gz-cmake/compare/gz-cmake3_3.5.6...gz-cmake3

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
