### PR TITLE
Prepare for 2.18.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.17.3)
+project(ignition-cmake2 VERSION 2.18.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,6 @@
     * [Pull request #556](https://github.com/gazebosim/gz-cmake/pull/556)
 
 1. Use portable shebang (#!/usr/bin/env bash) for bash scripts
-    * [Pull request #!/usr/bin/env bash) for bash scripts (#542](https://github.com/gazebosim/gz-cmake/pull/!/usr/bin/env bash) for bash scripts (#542)
     * [Pull request #542](https://github.com/gazebosim/gz-cmake/pull/542)
     * [Pull request #546](https://github.com/gazebosim/gz-cmake/pull/546)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,24 @@
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.18.0 (2026-05-14)
+
+1. cpack should exclude .git/ from tarballs
+    * [Pull request #552](https://github.com/gazebosim/gz-cmake/pull/552)
+    * [Pull request #556](https://github.com/gazebosim/gz-cmake/pull/556)
+
+1. Use portable shebang (#!/usr/bin/env bash) for bash scripts
+    * [Pull request #!/usr/bin/env bash) for bash scripts (#542](https://github.com/gazebosim/gz-cmake/pull/!/usr/bin/env bash) for bash scripts (#542)
+    * [Pull request #542](https://github.com/gazebosim/gz-cmake/pull/542)
+    * [Pull request #546](https://github.com/gazebosim/gz-cmake/pull/546)
+
+1. Make Whole Program Optimization (WPO) optional on MSVC
+    * [Pull request #532](https://github.com/gazebosim/gz-cmake/pull/532)
+    * [Pull request #536](https://github.com/gazebosim/gz-cmake/pull/536)
+
+1. Add a Doxygen filter for .h files (backport #523)
+    * [Pull request #523](https://github.com/gazebosim/gz-cmake/pull/523)
+    * [Pull request #527](https://github.com/gazebosim/gz-cmake/pull/527)
+
 ### Gazebo CMake 2.17.3 (2026-01-26)
 
 1. Fix dead material-design-lite links


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.18.0 release.

Comparison to 2.17.3: https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.17.3...ign-cmake2

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
