### PR TITLE
Set UID, GID to 0 in package archives

### DIFF
--- a/cmake/GzPackaging.cmake
+++ b/cmake/GzPackaging.cmake
@@ -52,6 +52,11 @@ macro(_gz_setup_packages)
     find_program(RPMBUILD_PROGRAM rpmbuild)
   endif()
 
+  # For reproducibility, use new behavior of CMP0206 to default UID, GID to zero in archives
+  if(POLICY CMP0206)
+    cmake_policy(SET CMP0206 NEW)
+  endif()
+
   list(APPEND CPACK_SOURCE_GENERATOR "TBZ2")
   list(APPEND CPACK_SOURCE_GENERATOR "ZIP")
   list(APPEND CPACK_SOURCE_IGNORE_FILES


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/issues/562

## Summary

This improves archive reproducibility with a feature added in cmake 4.3. Use if available through policy [CMP0206](https://cmake.org/cmake/help/latest/policy/CMP0206.html#policy:CMP0206).

## Test it

1. Build or install cmake 4.3 on a Linux system with `dpkg` installed (see [this logic](https://github.com/gazebosim/gz-cmake/blob/111ccb65fbdb8e03bcd0c445f378439c47fa457a/cmake/GzPackaging.cmake#L46-L53) which only adds a cpack generator on Linux if `dpkg` is found)
2. Use this version of cmake to configure a package (such as this branch of `cmake`)
3. Run `make package_source`
4. Use `tar --list --numeric-owner -tf gz-cmake-6.0.0~pre1.tar.bz2 | head` to verify that the UID and GID are both `0`

~~~
# note the 0/0 after the permissions
$ tar --list --numeric-owner -tf gz-cmake-6.0.0~pre1.tar.bz2 | head
drwxr-xr-x 0/0               0 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/
-rw-r--r-- 0/0             139 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/CODEOWNERS
drwxr-xr-x 0/0               0 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/ci/
-rw-r--r-- 0/0              33 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/ci/packages.apt
drwxr-xr-x 0/0               0 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/workflows/
-rw-r--r-- 0/0             872 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/workflows/ci.yml
-rw-r--r-- 0/0             208 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/workflows/package_xml.yml
-rw-r--r-- 0/0             313 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/workflows/pr-collection-labeler.yml
-rw-r--r-- 0/0             393 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.github/workflows/triage.yml
-rw-r--r-- 0/0              68 2026-05-15 17:11 gz-cmake-6.0.0~pre1/.gitignore
~~~

<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
