### PR TITLE
Avoid dangling pkg-config version when IgnProtobuf has no version

### DIFF
--- a/cmake/FindIgnProtobuf.cmake
+++ b/cmake/FindIgnProtobuf.cmake
@@ -24,7 +24,16 @@
 # support shared library versions of Protobuf.
 
 include(IgnPkgConfig)
-ign_pkg_config_entry(IgnProtobuf "protobuf >= ${IgnProtobuf_FIND_VERSION}")
+# Only add a version constraint to the pkg-config entry when a version was
+# actually requested. Otherwise the entry would be "protobuf >= " with a
+# dangling operator and no version, which makes pkg-config consume the next
+# token in the Requires line as protobuf's version, silently dropping that
+# dependency. See https://github.com/gazebosim/gz-msgs/issues/594
+if(IgnProtobuf_FIND_VERSION)
+  ign_pkg_config_entry(IgnProtobuf "protobuf >= ${IgnProtobuf_FIND_VERSION}")
+else()
+  ign_pkg_config_entry(IgnProtobuf "protobuf")
+endif()
 
 find_package(Protobuf ${IgnProtobuf_FIND_VERSION} QUIET CONFIG)
 


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-msgs/issues/594

## Summary

When ign_find_package(IgnProtobuf ...) is called without a VERSION,
IgnProtobuf_FIND_VERSION is empty and the generated pkg-config entry
became "protobuf >= " (a dangling operator with no version). pkg-config
then parses the following token in the Requires line as protobuf's
version, silently dropping that dependency.

For ignition-msgs8 this dropped ignition-math6 from the generated .pc
("protobuf >=  ignition-math6"), so consumers compiling against
`pkg-config --cflags ignition-msgs8` lost the ignition-math6 include
path and failed with: ignition/math/AxisAlignedBox.hh: No such file or
directory (surfaced by the ign-msgs8 debbuilder autopkgtest).

Guard the version constraint so the entry is a plain "protobuf" when no
version is requested.

Fixes gazebosim/gz-msgs#594

Generated-by: claude-opus-4-8

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
