### PR TITLE
[Fortress] Prepare gz-cmake 2.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-cmake2 VERSION 2.18.0)
+project(ignition-cmake2 VERSION 2.19.0)
 
 #--------------------------------------
 # Initialize the IGNITION_CMAKE_DIR variable with the location of the cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo CMake 2.x
 
+### Gazebo CMake 2.19.0 (2026-06-12)
+
+1. Avoid dangling pkg-config version when IgnProtobuf has no version
+    * [Pull request #567](http://github.com/gazebosim/gz-cmake/pull/567)
+
 ### Gazebo CMake 2.18.0 (2026-05-14)
 
 1. cpack should exclude .git/ from tarballs


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.19.0 release.

Comparison to 2.18.0: [https://github.com/gazebosim/<REPO>/compare/<LATEST_TAG_BRANCH>...<RELEASE_BRANCH>
](https://github.com/gazebosim/gz-cmake/compare/ignition-cmake2_2.18.0...ign-cmake2?expand=1)

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
