### PR TITLE
docs: link README install section to Gazebo CMake docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ These modules are tailored to the Gazebo projects, so their use for non-Gazebo p
 
 # Install
 
+For complete platform-specific installation instructions, see the
+[Gazebo CMake installation guide](https://gazebosim.org/api/cmake/4/install.html).
+
 We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
 
 The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These modules are tailored to the Gazebo projects, so their use for non-Gazebo p
 # Install
 
 For complete platform-specific installation instructions, see the
-[Gazebo CMake installation guide](https://gazebosim.org/api/cmake/4/install.html).
+[Gazebo CMake installation guide](https://github.com/gazebosim/gz-cmake/blob/main/tutorials/install.md).
 
 We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
 


### PR DESCRIPTION
## Summary
- add the official Gazebo CMake installation guide link to the README install section
- keep the existing abbreviated binary/source examples in place

## Validation
- `git diff --check`
- `Invoke-WebRequest -UseBasicParsing -Method Head https://gazebosim.org/api/cmake/4/install.html` returned `200`

Fixes #471