### PR TITLE
Set CMP0219 policy to OLD

### DIFF
--- a/cmake/GzAddComponent.cmake
+++ b/cmake/GzAddComponent.cmake
@@ -72,6 +72,13 @@
 # library, then you probably do not need to specify the standard, because it
 # will get inherited from the core library.
 function(gz_add_component component_name)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: gz_string_append
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  cmake_policy(PUSH)
+  if(POLICY CMP0219)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
   # Define the expected arguments
   set(options INTERFACE INDEPENDENT_FROM_PROJECT_LIB PRIVATELY_DEPENDS_ON_PROJECT_LIB INTERFACE_DEPENDS_ON_PROJECT_LIB)
   set(oneValueArgs INCLUDE_SUBDIR GET_TARGET_NAME)
@@ -262,4 +269,5 @@ function(gz_add_component component_name)
     set_property(TARGET ${PROJECT_LIBRARY_TARGET_NAME}-all
       PROPERTY INTERFACE_GZ_ALL_KNOWN_COMPONENTS "${all_known_components};${component_target_name}")
   endif()
+  cmake_policy(POP)
 endfunction()

--- a/cmake/GzConfigureBuild.cmake
+++ b/cmake/GzConfigureBuild.cmake
@@ -30,6 +30,13 @@
 # Pass the argument QUIT_IF_BUILD_ERRORS to have this macro quit cmake when the
 # build_errors
 macro(gz_configure_build)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: gz_string_append
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  if(POLICY CMP0219)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
   # Parse the arguments that are passed in
   set(options HIDE_SYMBOLS_BY_DEFAULT EXPOSE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
   set(oneValueArgs)
@@ -288,6 +295,9 @@ macro(gz_configure_build)
 
   endif()
 
+  if(POLICY CMP0219)
+    cmake_policy(POP)
+  endif()
 endmacro()
 
 macro(_gz_set_cxx_feature_flags)

--- a/cmake/GzCreateDocs.cmake
+++ b/cmake/GzCreateDocs.cmake
@@ -41,6 +41,13 @@
 # TAGFILES: Optional. Specify tagfiles for doxygen to use. It should be a list of strings like:
 #           "${GZ-<DESIGNATION>_DOXYGEN_TAGFILE} = ${GZ-<DESIGNATION>_API_URL}"
 function(gz_create_docs)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: gz_string_append
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  cmake_policy(PUSH)
+  if(POLICY CMP0219)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
 
   #------------------------------------
   # Define the expected arguments
@@ -201,7 +208,9 @@ function(gz_create_docs)
   if (DOC_ONLY)
     message(WARNING "Configuration was done in DOC_ONLY mode."
     " You can build documentation (make doc), but nothing else.")
+    cmake_policy(POP)
     return()
   endif()
 
+  cmake_policy(POP)
 endfunction()

--- a/cmake/GzFindPackage.cmake
+++ b/cmake/GzFindPackage.cmake
@@ -152,6 +152,13 @@
 #                             out, whether or not it is provided.
 #
 macro(gz_find_package PACKAGE_NAME_)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: gz_string_append
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  if(POLICY CMP0219)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
   set(PACKAGE_NAME ${PACKAGE_NAME_})  # Allow for variable rebinds
 
   # Define the expected arguments
@@ -466,4 +473,7 @@ macro(gz_find_package PACKAGE_NAME_)
 
   endif()
 
+  if(POLICY CMP0219)
+    cmake_policy(POP)
+  endif()
 endmacro()

--- a/cmake/GzStringAppend.cmake
+++ b/cmake/GzStringAppend.cmake
@@ -23,6 +23,13 @@
 #
 # Macro to append a value to a string
 macro(gz_string_append output_var val)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: _gz_cmake_parse_arguments
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  if(POLICY CMP0219)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
   # Define the expected arguments
   # NOTE: options cannot be set to PARENT_SCOPE alone, so we put it explicitly
   # into cmake_parse_arguments(~). We use a semicolon to concatenate it with
@@ -53,4 +60,7 @@ macro(gz_string_append output_var val)
     set(${output_var} "${${output_var}}" PARENT_SCOPE)
   endif()
 
+  if(POLICY CMP0219)
+    cmake_policy(POP)
+  endif()
 endmacro()

--- a/cmake/GzUtils.cmake
+++ b/cmake/GzUtils.cmake
@@ -290,6 +290,13 @@ endmacro()
 # Other Gazebo projects should not use this macro.
 #
 macro(_gz_cmake_parse_arguments prefix options oneValueArgs multiValueArgs)
+  # Control CMP0219 policy (Macro invocations preserve backslashes in arguments)
+  # Needed for: cmake_parse_arguments
+  # See https://github.com/gazebosim/gz-cmake/issues/570
+  if(POLICY CMP0219)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0219 OLD)
+  endif()
 
   cmake_parse_arguments(${prefix} "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -306,4 +313,7 @@ macro(_gz_cmake_parse_arguments prefix options oneValueArgs multiValueArgs)
 
   endif()
 
+  if(POLICY CMP0219)
+    cmake_policy(POP)
+  endif()
 endmacro()


### PR DESCRIPTION
# 🦟 Bug fix

Part of #570 

## Summary
On CMake 4.4.0+, a warning is triggered about policy [`CMP0219`](https://cmake.org/cmake/help/latest/policy/CMP0219.html) not being set:
```
CMake Warning (policy) at /usr/local/share/cmake/gz-cmake/cmake6/GzStringAppend.cmake:35 (_gz_cmake_parse_arguments):
  Policy CMP0219 is not set: Macro invocations preserve backslashes in
  arguments.  Run "cmake --help-policy CMP0219" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
```

In `gz-cmake`, macros like `gz_string_append` and `_gz_cmake_parse_arguments` rely on the `OLD` behavior where backslashes in macro arguments are unescaped during macro substitution (e.g., `gz_string_append` uses a double-macro-expansion workaround with 8 backslashes to get a single backslash in the output). Setting this policy to `OLD` explicitly silences the deprecation warning on CMake 4.4+ while ensuring this behavior remains correct.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the main

Assisted-by: Gemini 3.5 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

