### PR TITLE
Remove outdated cmake policies

### DIFF
--- a/cmake/FindGzAssimp.cmake
+++ b/cmake/FindGzAssimp.cmake
@@ -18,8 +18,6 @@
 # Provides a GzAssimp alias to avoid conflicts with other packages
 # that might provide a FindAssimp function, such as dartsim
 
-# Set CMP0012 policy to NEW to avoid OLD policy warning in assimp 5.0.1
-set(CMAKE_POLICY_DEFAULT_CMP0012 NEW)
 find_package(assimp CONFIG QUIET)
 
 set(GzAssimp_FOUND ${assimp_FOUND})

--- a/cmake/GzAddComponent.cmake
+++ b/cmake/GzAddComponent.cmake
@@ -80,10 +80,6 @@ function(gz_add_component component_name)
   # Parse the arguments
   cmake_parse_arguments(gz_add_component "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  if(POLICY CMP0079)
-    cmake_policy(SET CMP0079 NEW)
-  endif()
-
   if(gz_add_component_SOURCES)
     set(sources ${gz_add_component_SOURCES})
   elseif(NOT gz_add_component_INTERFACE)


### PR DESCRIPTION
# 🦟 Bug fix

Remove `cmake_policy` statements for outdated policies

## Summary

This removes `cmake_policy` statements explicitly setting the `NEW` behavior of [CMP0079](https://cmake.org/cmake/help/latest/policy/CMP0079.html) (added in cmake 3.13) and [CMP0012](https://cmake.org/cmake/help/latest/policy/CMP0012.html) (added in cmake 2.8.0), since the new behavior is already in use with our minimum cmake version (3.22.1).

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
